### PR TITLE
Describe build & runtime dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Build Status](https://travis-ci.com/ashleygwilliams/cargo-generate.svg?branch=master)](https://travis-ci.com/ashleygwilliams/cargo-generate)
 
 `cargo-generate` is a developer tool to help you get up and running quickly with a new Rust
-project by leveraging a pre-existing git repository as a template. 
+project by leveraging a pre-existing git repository as a template.
 
 Here's an example of using `cargo-generate` with [this template]:
 ![demo.gif](./demo.gif)
@@ -18,6 +18,17 @@ Here's an example of using `cargo-generate` with [this template]:
 ```
 cargo install cargo-generate
 ```
+
+`cargo-generate` has a few dependencies that need to be available before it can be installed and used.
+
+* `openssl`: See the [`openssl-sys` crate readme] on how to obtain the openssl library for your system.
+* [`git`]: It is used to download the templates.
+* `cmake`: Check if it is installed by typing `cmake --version` in a terminal or command line window. If it is not available, check your package
+  manager or see the [cmake homepage].
+
+[`openssl-sys` crate readme]: https://crates.io/crates/openssl-sys
+[`git`]: https://git-scm.com/downloads
+[cmake homepage]: https://cmake.org/download/
 
 ## Usage
 


### PR DESCRIPTION
As discussed in #42, there are a few dependencies that have to be met before `cargo-generate` can be installed and run. I left out the installation of build-essential resp. a C compiler because it is already described in the [rust install guide](https://doc.rust-lang.org/book/second-edition/ch01-01-installation.html). Everybody developing with rust should already have this. The `openssl-sys` crate already described how to install the openssl library so I just added a link to their crate page.