### PR TITLE
test(case): project names are kebabs

### DIFF
--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -1,7 +1,6 @@
 use console::style;
 use dialoguer::Input;
 use emoji;
-use heck::KebabCase;
 use quicli::prelude::Error;
 use regex;
 
@@ -14,14 +13,6 @@ pub fn name() -> Result<String, Error> {
             style("Project Name").bold()
         )).interact()?;
         if valid_ident.is_match(&name) {
-
-            println!(
-                "{} {} `{}`{}",
-                emoji::WRENCH,
-                style("Creating project called").bold(),
-                style(&name.to_kebab_case()).bold().yellow(),
-                style("...").bold()
-            );
             break name;
         } else {
             eprintln!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,13 +68,13 @@ main!(|_cli: Cli| {
         "{} {} `{}`{}",
         emoji::WRENCH,
         style("Creating project called").bold(),
-        style(&name.kebab_case).bold().yellow(),
+        style(&name.kebab_case()).bold().yellow(),
         style("...").bold()
     );
 
     let project_dir = env::current_dir()
         .unwrap_or_else(|_e| ".".into())
-        .join(&name.kebab_case);
+        .join(&name.kebab_case());
 
     ensure!(
         !project_dir.exists(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,7 @@ main!(|_cli: Cli| {
     git::create(&project_dir, args)?;
     git::remove_history(&project_dir)?;
 
-    let template = template::substitute(&name.kebab_case)?;
+    let template = template::substitute(&name)?;
 
     let pbar = progressbar::new();
     pbar.tick();

--- a/src/projectname.rs
+++ b/src/projectname.rs
@@ -1,0 +1,15 @@
+use heck::{KebabCase, SnakeCase};
+
+pub struct ProjectName {
+    pub kebab_case: String,
+    pub snake_case: String,
+}
+
+impl ProjectName {
+    pub fn new(name: &str) -> ProjectName {
+        ProjectName {
+            kebab_case: name.to_kebab_case(),
+            snake_case: name.to_snake_case(),
+        }
+    }
+}

--- a/src/projectname.rs
+++ b/src/projectname.rs
@@ -1,5 +1,7 @@
 use heck::{KebabCase, SnakeCase};
 
+/// Stores user inputted name and provides convenience methods
+/// for handling casing.
 pub struct ProjectName {
     user_input: String,
 }

--- a/src/projectname.rs
+++ b/src/projectname.rs
@@ -1,15 +1,21 @@
 use heck::{KebabCase, SnakeCase};
 
 pub struct ProjectName {
-    pub kebab_case: String,
-    pub snake_case: String,
+    user_input: String,
 }
 
 impl ProjectName {
     pub fn new(name: &str) -> ProjectName {
         ProjectName {
-            kebab_case: name.to_kebab_case(),
-            snake_case: name.to_snake_case(),
+            user_input: name.to_string(),
         }
+    }
+
+    pub fn kebab_case(&self) -> String {
+        self.user_input.to_kebab_case()
+    }
+
+    pub fn snake_case(&self) -> String {
+        self.user_input.to_snake_case()
     }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -3,6 +3,7 @@ use console::style;
 use emoji;
 use indicatif::ProgressBar;
 use liquid;
+use projectname::ProjectName;
 use quicli::prelude::*;
 use std::fs;
 use std::path::PathBuf;
@@ -12,22 +13,21 @@ fn engine() -> liquid::Parser {
     liquid::ParserBuilder::new().build()
 }
 
-pub fn substitute(name: &str) -> Result<liquid::Object> {
+pub fn substitute(name: &ProjectName) -> Result<liquid::Object> {
     let mut template = liquid::Object::new();
-    template.insert(String::from("project-name"), liquid::Value::scalar(name));
+    template.insert(
+        String::from("project-name"),
+        liquid::Value::scalar(&name.kebab_case),
+    );
     template.insert(
         String::from("crate_name"),
-        liquid::Value::scalar(&hyphen_to_lodash(name)),
+        liquid::Value::scalar(&name.snake_case),
     );
     template.insert(
         String::from("authors"),
         liquid::Value::scalar(&cargo::get_authors()?),
     );
     Ok(template)
-}
-
-fn hyphen_to_lodash(string: &str) -> String {
-    string.to_string().replace("-", "_")
 }
 
 pub fn walk_dir(project_dir: &PathBuf, template: liquid::Object, pbar: ProgressBar) -> Result<()> {

--- a/src/template.rs
+++ b/src/template.rs
@@ -17,11 +17,11 @@ pub fn substitute(name: &ProjectName) -> Result<liquid::Object> {
     let mut template = liquid::Object::new();
     template.insert(
         String::from("project-name"),
-        liquid::Value::scalar(&name.kebab_case),
+        liquid::Value::scalar(&name.kebab_case()),
     );
     template.insert(
         String::from("crate_name"),
-        liquid::Value::scalar(&name.snake_case),
+        liquid::Value::scalar(&name.snake_case()),
     );
     template.insert(
         String::from("authors"),

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -41,7 +41,7 @@ version = "0.1.0"
 }
 
 #[test]
-fn it_snakecases_projectname_when_passed_to_flag() {
+fn it_kebabcases_projectname_when_passed_to_flag() {
     let template = dir("template")
         .file(
             "Cargo.toml",

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -41,6 +41,40 @@ version = "0.1.0"
 }
 
 #[test]
+fn it_snakecases_projectname_when_passed_to_flag() {
+    let template = dir("template")
+        .file(
+            "Cargo.toml",
+            r#"[package]
+name = "{{project-name}}"
+description = "A wonderful project"
+version = "0.1.0"
+"#,
+        )
+        .init_git()
+        .build();
+
+    let dir = dir("main").build();
+
+    Command::main_binary()
+        .unwrap()
+        .arg("generate")
+        .arg("--git")
+        .arg(template.path())
+        .arg("--name")
+        .arg("foobar_project")
+        .current_dir(&dir.path())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Done!").from_utf8());
+
+    assert!(
+        dir.read("foobar-project/Cargo.toml")
+            .contains("foobar-project")
+    );
+}
+
+#[test]
 fn it_substitutes_cratename_in_a_rust_file() {
     let template = dir("template")
         .file(


### PR DESCRIPTION
👾 do no merge 👾 

fixes #63 and adds tests for:

- when `--name` is passed to generate it should be kebab'd