### PR TITLE
WIP: Shallow main

### DIFF
--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -1,0 +1,35 @@
+#[macro_use]
+extern crate quicli;
+extern crate cargo_generate;
+
+use cargo_generate::{Cli, generate};
+use quicli::prelude::StructOpt;
+
+/// Generate a new Cargo project from a given template
+///
+/// Right now, only git repositories can be used as templates. Just execute
+///
+/// $ cargo generate --git https://github.com/user/template.git --name foo
+///
+/// or
+///
+/// $ cargo gen --git https://github.com/user/template.git --name foo
+///
+/// and a new Cargo project called foo will be generated.
+///
+/// TEMPLATES:
+///
+/// In templates, the following placeholders can be used:
+///
+/// - `project-name`: Name of the project, in dash-case
+///
+/// - `crate_name`: Name of the project, but in a case valid for a Rust
+///   identifier, i.e., snake_case
+///
+/// - `authors`: Author names, taken from usual environment variables (i.e.
+///   those which are also used by Cargo and git)
+main!(|_cli: Cli| {
+    
+    generate(_cli);
+
+});


### PR DESCRIPTION
#81 I'm working on building a little generate lib.
I try to handle all errors internally so it will just print out the problem to the user without the use of  `?`.
To make the main really shallow, we may have to remove `quicli`. 

Also #79 is handled a little better in this build since the tells the user that it's a git specific error.
 
I still have to do some more refactoring and error handling. I'm also thinking about adding a few more specific tests to check the error handling. 

I'm also open for more suggestions eg. better names and co. 🐬
