### PR TITLE
added ignore files capabilites 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,7 @@ dependencies = [
  "dialoguer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ignore 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "liquid 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "predicates 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -173,6 +174,11 @@ dependencies = [
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "crossbeam"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "crossbeam-deque"
@@ -293,6 +299,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +337,18 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "globset"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,6 +372,23 @@ dependencies = [
  "matches 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "globset 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1059,6 +1099,7 @@ dependencies = [
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "b56821938fa1a3aaf4f0c4f49504928c5a7fcc56cbc9855be8fc2e98567e750c"
 "checksum console 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7649ca90478264b9686aac8d269fcb014f14c2bed7c79a7e51b9f6afd4d783eb"
+"checksum crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "24ce9782d4d5c53674646a6a4c1863a21a8fc0cb649b3c94dfc16e45071dea19"
 "checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
 "checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
@@ -1072,13 +1113,16 @@ dependencies = [
 "checksum failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7efb22686e4a466b1ec1a15c2898f91fa9cb340452496dca654032de20ff95b9"
 "checksum failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "946d0e98a50d9831f5d589038d2ca7f8f455b1c21028c0db0e84116a12696426"
 "checksum float-cmp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "134a8fa843d80a51a5b77d36d42bc2def9edcb0262c914861d08129fd1926600"
+"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum git2 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "591f8be1674b421644b6c030969520bc3fa12114d2eb467471982ed3e9584e71"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum globset 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8e49edbcc9c7fc5beb8c0a54e7319ff8bed353a2b55e85811c6281188c2a6c84"
 "checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+"checksum ignore 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3e9faa7c84064f07b40da27044af629f578bc7994b650d3e458d0c29183c1d91"
 "checksum indicatif 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a29b2fa6f00010c268bface64c18bb0310aaa70d46a195d5382d288c477fb016"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5adb58558dcd1d786b5f0bd15f3226ee23486e24b7b58304b60f64dc68e62606"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ heck = "0.3.0"
 liquid = "0.14.3"
 walkdir = "2.1.4"
 remove_dir_all = "0.5.1"
+ignore = "0.4.3"
 
 [dev-dependencies]
 predicates = "0.5.0"

--- a/src/ignoreme.rs
+++ b/src/ignoreme.rs
@@ -14,9 +14,10 @@ pub fn remove_uneeded_files(dir: &PathBuf) {
 }
 
 fn get_ignored(location: &PathBuf) -> Option<Vec<PathBuf>> {
+    let ignore_file_name = ".genignore";
     let ignored = WalkBuilder::new(location)
         .standard_filters(false)
-        .add_custom_ignore_filename(OsStr::new(".genignore"))
+        .add_custom_ignore_filename(OsStr::new(ignore_file_name))
         .build()
         .into_iter()
         .map(|x| x.unwrap());

--- a/src/ignoreme.rs
+++ b/src/ignoreme.rs
@@ -1,0 +1,54 @@
+use ignore::WalkBuilder;
+use remove_dir_all::*;
+use std::collections::HashSet;
+use std::ffi::OsStr;
+use std::path::PathBuf;
+use std::fs::remove_file;
+
+pub fn get_ignored(location: &str) -> Option<Vec<PathBuf>> {
+    let ignored = WalkBuilder::new(location)
+        .standard_filters(false)
+        .add_custom_ignore_filename(OsStr::new(".genignore"))
+        .build()
+        .into_iter()
+        .map(|x| x.unwrap());
+
+    let all = WalkBuilder::new(location)
+        .standard_filters(false)
+        .build()
+        .into_iter()
+        .map(|x| x.unwrap());
+
+    let mut all_set = HashSet::new();
+    let mut ign_set = HashSet::new();
+    let mut output = vec![];
+
+    for x in all {
+        all_set.insert(x.path().to_owned());
+    }
+    for x in ignored {
+        ign_set.insert(x.path().to_owned());
+    }
+    for x in all_set.difference(&ign_set) {
+        output.push(x.to_owned());
+    }
+    if output.is_empty() {
+        None
+    } else {
+        Some(output)
+    }
+}
+
+fn remove_ignored(ignore: Vec<PathBuf>) {
+    for item in ignore{
+        if item.is_dir(){
+            remove_dir_all(&item).unwrap();
+            println!("Removed: {:?}", &item)
+        }else if item.is_file() {
+            remove_file(&item).unwrap();
+            println!("Removed: {:?}", &item)
+        }else {
+            println!("The given paths are neither files nor directories! {:?}", &item);
+        }
+    }
+}

--- a/src/ignoreme.rs
+++ b/src/ignoreme.rs
@@ -2,10 +2,18 @@ use ignore::WalkBuilder;
 use remove_dir_all::*;
 use std::collections::HashSet;
 use std::ffi::OsStr;
-use std::path::PathBuf;
 use std::fs::remove_file;
+use std::path::PathBuf;
 
-pub fn get_ignored(location: &str) -> Option<Vec<PathBuf>> {
+//FIXME: function returns Result
+pub fn remove_uneeded_files(dir: &PathBuf) {
+    match get_ignored(dir) {
+        Some(items) => remove_dir_files(items),
+        None => println!("Nothing to remove!"),
+    }
+}
+
+fn get_ignored(location: &PathBuf) -> Option<Vec<PathBuf>> {
     let ignored = WalkBuilder::new(location)
         .standard_filters(false)
         .add_custom_ignore_filename(OsStr::new(".genignore"))
@@ -39,16 +47,27 @@ pub fn get_ignored(location: &str) -> Option<Vec<PathBuf>> {
     }
 }
 
-fn remove_ignored(ignore: Vec<PathBuf>) {
-    for item in ignore{
-        if item.is_dir(){
+//FIXME:
+fn sanititze(items: Vec<PathBuf>) -> Option<Vec<PathBuf>> {
+    unimplemented!()
+}
+
+//FIXME:
+fn remove_dir_files(ignore: Vec<PathBuf>) {
+    let sanitized_files = ignore; //sanititze(ignore);
+
+    for item in sanitized_files {
+        if item.is_dir() {
             remove_dir_all(&item).unwrap();
             println!("Removed: {:?}", &item)
-        }else if item.is_file() {
+        } else if item.is_file() {
             remove_file(&item).unwrap();
             println!("Removed: {:?}", &item)
-        }else {
-            println!("The given paths are neither files nor directories! {:?}", &item);
+        } else {
+            println!(
+                "The given paths are neither files nor directories! {:?}",
+                &item
+            );
         }
     }
 }

--- a/src/ignoreme.rs
+++ b/src/ignoreme.rs
@@ -5,12 +5,14 @@ use std::ffi::OsStr;
 use std::fs::remove_file;
 use std::path::PathBuf;
 
-//FIXME: function returns Result
+///takes the directory path and removes the files/directories specified in the
+/// `.genignore` file
+/// It handles all errors internally
 pub fn remove_uneeded_files(dir: &PathBuf) {
     match get_ignored(dir) {
         Some(items) => remove_dir_files(items),
-        None => println!("Nothing to remove!"),
-    }
+        None => (),
+    };
 }
 
 fn get_ignored(location: &PathBuf) -> Option<Vec<PathBuf>> {
@@ -19,24 +21,22 @@ fn get_ignored(location: &PathBuf) -> Option<Vec<PathBuf>> {
         .standard_filters(false)
         .add_custom_ignore_filename(OsStr::new(ignore_file_name))
         .build()
-        .into_iter()
-        .map(|x| x.unwrap());
+        .into_iter();
 
     let all = WalkBuilder::new(location)
         .standard_filters(false)
         .build()
-        .into_iter()
-        .map(|x| x.unwrap());
+        .into_iter();
 
     let mut all_set = HashSet::new();
     let mut ign_set = HashSet::new();
     let mut output = vec![];
 
     for x in all {
-        all_set.insert(x.path().to_owned());
+        all_set.insert(x.expect("Found invalid path: Aborting").path().to_owned());
     }
     for x in ignored {
-        ign_set.insert(x.path().to_owned());
+        ign_set.insert(x.expect("Found invalid path: Aborting").path().to_owned());
     }
     for x in all_set.difference(&ign_set) {
         output.push(x.to_owned());
@@ -48,14 +48,14 @@ fn get_ignored(location: &PathBuf) -> Option<Vec<PathBuf>> {
     }
 }
 
-//FIXME:
+//TODO: DO we acutally need sanitizing the pathbuffer ?
+//Probably not in this case
 fn sanititze(items: Vec<PathBuf>) -> Option<Vec<PathBuf>> {
-    unimplemented!()
+    Some(items)
 }
 
-//FIXME:
 fn remove_dir_files(ignore: Vec<PathBuf>) {
-    let sanitized_files = ignore; //sanititze(ignore);
+    let sanitized_files = sanititze(ignore).expect("Invalid Files ABORT REMOVING");
 
     for item in sanitized_files {
         if item.is_dir() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,11 +9,13 @@ extern crate liquid;
 extern crate regex;
 extern crate remove_dir_all;
 extern crate walkdir;
+extern crate ignore;
 
 mod cargo;
 mod emoji;
 mod git;
 mod interactive;
+mod ignoreme;
 mod progressbar;
 mod projectname;
 mod template;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,18 +4,18 @@ extern crate console;
 extern crate dialoguer;
 extern crate git2;
 extern crate heck;
+extern crate ignore;
 extern crate indicatif;
 extern crate liquid;
 extern crate regex;
 extern crate remove_dir_all;
 extern crate walkdir;
-extern crate ignore;
 
 mod cargo;
 mod emoji;
 mod git;
-mod interactive;
 mod ignoreme;
+mod interactive;
 mod progressbar;
 mod projectname;
 mod template;
@@ -111,6 +111,9 @@ main!(|_cli: Cli| {
     template::walk_dir(&project_dir, template, pbar)?;
 
     git::init(&project_dir)?;
+
+    //remove uneeded here
+    ignoreme::remove_uneeded_files(&project_dir);
 
     let dir_string = &project_dir.to_str().unwrap_or("");
     println!(

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -184,26 +184,23 @@ fn it_removes_unneeded_files() {
 name = "{{project-name}}"
 description = "A wonderful project"
 version = "0.1.0"
-"#,     ).file(
+"#,
+        )
+        .file(
             ".genignore",
             r#"deleteme.sh
 sampledir
 *.trash
-"#,     ).file(
-            "deleteme.sh",
-            r#"Nothing to see here"#
-        ).file(
-            "deleteme.trash",
-            r#"This is trash"#
-        ).file(
-            "notme.sh",
-            r#"I'm here!"#
+"#,
         )
+        .file("deleteme.sh", r#"Nothing to see here"#)
+        .file("deleteme.trash", r#"This is trash"#)
+        .file("notme.sh", r#"I'm here!"#)
         .init_git()
         .build();
 
     let dir = dir("main").build();
-    
+
     Command::main_binary()
         .unwrap()
         .arg("gen")

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -174,7 +174,6 @@ version = "0.1.0"
     );
 }
 
-//TODO: Finish this test
 #[test]
 fn it_removes_unneeded_files() {
     let template = dir("template")
@@ -188,8 +187,8 @@ version = "0.1.0"
         )
         .file(
             ".genignore",
-            r#"deleteme.sh
-sampledir
+            r#".genignore
+deleteme.sh
 *.trash
 "#,
         )
@@ -213,9 +212,11 @@ sampledir
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
 
-    assert!(dir.exists("foobar-project/notme.sh"));
-    assert!(!dir.exists("foobar-project/deleteme.sh"));
-    assert!(!dir.exists("foobar-project/deleteme.trash"));
+    assert_eq!(dir.exists("foobar-project/notme.sh"), true);
+    assert_eq!(dir.exists("foobar-project/.genignore"), false);
+    assert_eq!(dir.exists("foobar-project/deleteme.sh"), false);
+    assert_eq!(dir.exists("foobar-project/deleteme.trash"), false);
+
     assert!(
         dir.read("foobar-project/Cargo.toml")
             .contains("foobar-project")

--- a/tests/integration/helpers/project.rs
+++ b/tests/integration/helpers/project.rs
@@ -3,6 +3,7 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::str;
 
+#[derive(Debug)]
 pub struct Project {
     pub root: PathBuf,
 }
@@ -19,6 +20,10 @@ impl Project {
 
     pub fn path(&self) -> &Path {
         &self.root
+    }
+
+    pub fn exists(&self, path: &str) -> bool {
+        self.root.join(path).exists()
     }
 }
 


### PR DESCRIPTION
Solving #82 

Maybe a little hacky to solve this problem but it can read a `.genignore `file and remove the contents specified in this file.
I would also make it optional with the default = true

Do we really want to call it `.genignore` or are there better names for it?

> TODO:
> + Boundary Checks against malicious ignore files necessary? 
