### PR TITLE
Add support for specifying git branch

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -7,10 +7,14 @@ use std::path::PathBuf;
 use Args;
 
 pub fn create(project_dir: &PathBuf, args: Args) -> Result<GitRepository> {
-    Ok(RepoBuilder::new()
-        .bare(false)
-        .with_checkout(CheckoutBuilder::new())
-        .clone(&args.git, &project_dir)?)
+    let mut rb = RepoBuilder::new();
+    rb.bare(false).with_checkout(CheckoutBuilder::new());
+
+    if let Some(ref branch) = args.branch {
+        rb.branch(branch);
+    }
+
+    Ok(rb.clone(&args.git, &project_dir)?)
 }
 
 pub fn remove_history(project_dir: &PathBuf) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,8 +89,7 @@ main!(|_cli: Cli| {
         style("...").bold()
     );
 
-    let dir_name =
-        if force { name.raw() } else { name.kebab_case() };
+    let dir_name = if force { name.raw() } else { name.kebab_case() };
     let project_dir = env::current_dir()
         .unwrap_or_else(|_e| ".".into())
         .join(dir_name);

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,9 @@ pub enum Cli {
 pub struct Args {
     #[structopt(long = "git")]
     git: String,
+    // Branch to use when installing from git
+    #[structopt(long = "branch")]
+    branch: Option<String>,
     #[structopt(long = "name", short = "n")]
     name: Option<String>,
     /// Enforce to create a new project without case conversion of project name

--- a/src/template.rs
+++ b/src/template.rs
@@ -14,8 +14,7 @@ fn engine() -> liquid::Parser {
 }
 
 pub fn substitute(name: &ProjectName, force: bool) -> Result<liquid::Object> {
-    let project_name =
-        if force { name.raw() } else { name.kebab_case() };
+    let project_name = if force { name.raw() } else { name.kebab_case() };
 
     let mut template = liquid::Object::new();
     template.insert(

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -173,3 +173,41 @@ version = "0.1.0"
             .contains("foobar_project")
     );
 }
+
+#[test]
+fn it_allows_a_git_branch_to_be_specified() {
+    // Build and commit on mater
+    let template = dir("template")
+        .file(
+            "Cargo.toml",
+            r#"[package]
+name = "{{project-name}}"
+description = "A wonderful project"
+version = "0.1.0"
+"#,
+        )
+        .init_git()
+        .branch("baz")
+        .build();
+
+    let dir = dir("main").build();
+
+    Command::main_binary()
+        .unwrap()
+        .arg("generate")
+        .arg("--branch")
+        .arg("baz")
+        .arg("--git")
+        .arg(template.path())
+        .arg("--name")
+        .arg("foobar-project")
+        .current_dir(&dir.path())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Done!").from_utf8());
+
+    assert!(
+        dir.read("foobar-project/Cargo.toml")
+            .contains("foobar-project")
+    );
+}

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -16,8 +16,7 @@ name = "{{project-name}}"
 description = "A wonderful project"
 version = "0.1.0"
 "#,
-        )
-        .init_git()
+        ).init_git()
         .build();
 
     let dir = dir("main").build();
@@ -50,8 +49,7 @@ name = "{{project-name}}"
 description = "A wonderful project"
 version = "0.1.0"
 "#,
-        )
-        .init_git()
+        ).init_git()
         .build();
 
     let dir = dir("main").build();
@@ -82,8 +80,7 @@ fn it_substitutes_cratename_in_a_rust_file() {
             r#"
 extern crate {{crate_name}};          
 "#,
-        )
-        .init_git()
+        ).init_git()
         .build();
 
     let dir = dir("main").build();
@@ -115,8 +112,7 @@ name = "{{project-name}}"
 description = "A wonderful project"
 version = "0.1.0"
 "#,
-        )
-        .init_git()
+        ).init_git()
         .build();
 
     let dir = dir("main").build();
@@ -149,8 +145,7 @@ name = "{{project-name}}"
 description = "A wonderful project"
 version = "0.1.0"
 "#,
-        )
-        .init_git()
+        ).init_git()
         .build();
 
     let dir = dir("main").build();
@@ -185,8 +180,7 @@ name = "{{project-name}}"
 description = "A wonderful project"
 version = "0.1.0"
 "#,
-        )
-        .init_git()
+        ).init_git()
         .branch("baz")
         .build();
 


### PR DESCRIPTION
This mimics the `--branch` option available when performing
a `cargo install` from git.

I created this without first noticing https://github.com/ashleygwilliams/cargo-generate/pull/87 but after some discussion here it seemed like it made sense to open this as an alternative that addresses issues related to assuming that "master" was always the default branch on the remote.

CC @deg4uss3r