### PR TITLE
Fix/submodules init

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,43 @@ the version of cargo you are using (`cargo --version`), the version of Rust
 you are using (`rustc --version`) and your operating system and version. The
 faster was can reproduce your issue, the faster we can fix it for you!
 
+## Testing your code
+
+After writing your patch, or finishing an awesome feature, make sure that your
+code does not collides with the existing code in executing the unit tests.
+
+To execute the unit tests, please to run `cargo test` at the
+project root.
+
+For complex issues, and solutions, we did not created unit tests yet.
+For example, to test if your code does not collides with the solution of the
+[issue #83], you have to run those tests locally:
+
+**1. Clone an existing template, without any git submodule, locally**
+
+You can take one at the [Templates page].
+For example:
+
+```sh
+cargo generate --git https://github.com/rustwasm/wasm-pack-template
+```
+
+Once you tested the project has been correctly cloned and setted, please to
+do the same with a template that contains git submodules.
+
+**2. Clone an existing template, with at least one git submodule, locally**
+
+For example:
+
+```sh
+cargo generate --git https://github.com/k0pernicus/cargo-template-test-submodule
+```
+
+Please check that the project has been correctly cloned and setted, and check
+if the repository contains initialized submodules.
+
+**Your ideas/contributions are welcome to create automated tests for this** :)
+
 ## Submitting a PR
 
 If you are considering filing a pull request, make sure that there's an issue
@@ -66,3 +103,5 @@ read it. If you have any questions or concerns, feel free to reach out to
 Ashley Williams, ashley666ashley@gmail.com.
 
 [Code of Conduct]: CODE_OF_CONDUCT.md
+[issue #83]: https://github.com/ashleygwilliams/cargo-generate/issues/83
+[Templates page]: TEMPLATES.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,12 +26,12 @@ To execute the unit tests, we will use the `test` feature included in `cargo`:
 cargo test
 ```
 
-`cargo test` will execute the unit tests included in the `tests` directory.
+`cargo test` will execute the unit tests included in the `tests` directory.  
 If all the lights are green, you can then validate the manual tests.
 
 ### Manual tests
 
-For complex issues, and solutions, we did not created unit tests yet.
+For complex issues, and solutions, we did not created unit tests yet.  
 Otherwise, we have manual tests in order to check if everything is ok.
 
 For example, to test if your code does not collides with the solution of the
@@ -39,7 +39,7 @@ For example, to test if your code does not collides with the solution of the
 
 **1. Clone an existing template, without any git submodule, locally**
 
-You can take one at the [Templates page].
+You can take one at the [Templates page].  
 For example:
 
 ```sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,13 +15,25 @@ faster was can reproduce your issue, the faster we can fix it for you!
 
 ## Testing your code
 
-After writing your patch, or finishing an awesome feature, make sure that your
-code does not collides with the existing code in executing the unit tests.
+### Unit tests
 
-To execute the unit tests, please to run `cargo test` at the
-project root.
+After writing your patch, or finishing an awesome feature, make sure that your
+code does not collides with the existing code, in executing the unit tests.
+
+To execute the unit tests, we will use the `test` feature included in `cargo`:
+
+```sh
+cargo test
+```
+
+`cargo test` will execute the unit tests included in the `tests` directory.
+If all the lights are green, you can then validate the manual tests.
+
+### Manual tests
 
 For complex issues, and solutions, we did not created unit tests yet.
+Otherwise, we have manual tests in order to check if everything is ok.
+
 For example, to test if your code does not collides with the solution of the
 [issue #83], you have to run those tests locally:
 

--- a/README.md
+++ b/README.md
@@ -75,4 +75,7 @@ at your option.
 Unless you explicitly state otherwise, any contribution intentionally
 submitted for inclusion in the work by you, as defined in the Apache-2.0
 license, shall be dual licensed as above, without any additional terms or
-conditions.
+conditions.  
+If you want to contribute to `cargo-generate`, please read our [CONTRIBUTING notes].
+
+[CONTRIBUTING notes]: CONTRIBUTING.md

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,5 +1,6 @@
 use git2::{
-    build::CheckoutBuilder, build::RepoBuilder, Repository as GitRepository, RepositoryInitOptions, SubmoduleUpdateOptions
+    build::CheckoutBuilder, build::RepoBuilder, Repository as GitRepository, RepositoryInitOptions,
+    SubmoduleUpdateOptions,
 };
 use quicli::prelude::*;
 use remove_dir_all::remove_dir_all;
@@ -20,17 +21,19 @@ pub fn create(project_dir: &PathBuf, args: Args) -> Result<GitRepository> {
 pub fn load_submodules(git_repository: &GitRepository) -> Result<()> {
     let submodules = git_repository.submodules()?;
     if submodules.len() == 0 {
-        return Ok(())
+        return Ok(());
     }
 
     // Init submodule options
     let mut submodule_opts = SubmoduleUpdateOptions::new();
-    submodule_opts.allow_fetch(true).checkout(CheckoutBuilder::new());
+    submodule_opts
+        .allow_fetch(true)
+        .checkout(CheckoutBuilder::new());
 
     // Init and load each submodule
     for mut submodule in submodules {
         submodule.update(true, Some(&mut submodule_opts))?;
-    };
+    }
 
     Ok(())
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,5 +1,5 @@
 use git2::{
-    build::CheckoutBuilder, build::RepoBuilder, Repository as GitRepository, RepositoryInitOptions,
+    build::CheckoutBuilder, build::RepoBuilder, Repository as GitRepository, RepositoryInitOptions, SubmoduleUpdateOptions
 };
 use quicli::prelude::*;
 use remove_dir_all::remove_dir_all;
@@ -15,6 +15,24 @@ pub fn create(project_dir: &PathBuf, args: Args) -> Result<GitRepository> {
     }
 
     Ok(rb.clone(&args.git, &project_dir)?)
+}
+
+pub fn load_submodules(git_repository: &GitRepository) -> Result<()> {
+    let submodules = git_repository.submodules()?;
+    if submodules.len() == 0 {
+        return Ok(())
+    }
+
+    // Init submodule options
+    let mut submodule_opts = SubmoduleUpdateOptions::new();
+    submodule_opts.allow_fetch(true).checkout(CheckoutBuilder::new());
+
+    // Init and load each submodule
+    for mut submodule in submodules {
+        submodule.update(true, Some(&mut submodule_opts))?;
+    };
+
+    Ok(())
 }
 
 pub fn remove_history(project_dir: &PathBuf) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,7 +114,8 @@ main!(|_cli: Cli| {
         project_dir.display()
     );
 
-    git::create(&project_dir, args)?;
+    git::create(&project_dir, args)
+        .and_then(|ref git_repository| git::load_submodules(git_repository))?;
     git::remove_history(&project_dir)?;
 
     let template = template::substitute(&name, force)?;


### PR DESCRIPTION
This pull request is a proposition for issue #83.

Allow to initialize and update a git submodule from a given template repository.

This feature has been tested manually ( we need tests here - I am open to any proposals and ideas in the establishment of these tests :) ) in cloning a cargo template from:

* [rocket-base](https://github.com/k0pernicus/cargo-template-rocket-base),
* [a toy submodule git repository](https://github.com/k0pernicus/cargo-template-test-submodule).