### PR TITLE
[WIP] Rust 2018 migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,7 @@ dependencies = [
  "quicli 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ authors = [
 license = "MIT/Apache-2.0"
 repository = "https://github.com/ashleygwilliams/cargo-generate"
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
 cargo = "0.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ remove_dir_all = "0.5.1"
 ignore = "0.4.3"
 openssl = { version = '0.10.11', optional = true }
 url = "1.7.1"
+structopt = "0.2.14"
 
 [dev-dependencies]
 predicates = "0.5.0"

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate quicli;
 
-
 use cargo_generate::{generate, Cli};
 use quicli::prelude::StructOpt;
 

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -1,6 +1,6 @@
 #[macro_use]
 extern crate quicli;
-extern crate cargo_generate;
+
 
 use cargo_generate::{generate, Cli};
 use quicli::prelude::StructOpt;

--- a/src/git.rs
+++ b/src/git.rs
@@ -5,9 +5,9 @@ use std::env::current_dir;
 use std::path::Path;
 use std::path::PathBuf;
 use tempfile::Builder;
-use upstream::core::GitReference;
-use upstream::sources::git::GitRemote;
-use upstream::util::config::Config;
+use crate::upstream::core::GitReference;
+use crate::upstream::sources::git::GitRemote;
+use crate::upstream::util::config::Config;
 use url::{ParseError, Url};
 pub struct GitConfig {
     remote: Url,

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,3 +1,6 @@
+use crate::upstream::core::GitReference;
+use crate::upstream::sources::git::GitRemote;
+use crate::upstream::util::config::Config;
 use git2::{Repository as GitRepository, RepositoryInitOptions};
 use quicli::prelude::*;
 use remove_dir_all::remove_dir_all;
@@ -5,9 +8,6 @@ use std::env::current_dir;
 use std::path::Path;
 use std::path::PathBuf;
 use tempfile::Builder;
-use crate::upstream::core::GitReference;
-use crate::upstream::sources::git::GitRemote;
-use crate::upstream::util::config::Config;
 use url::{ParseError, Url};
 pub struct GitConfig {
     remote: Url,

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -1,6 +1,6 @@
+use crate::emoji;
 use console::style;
 use dialoguer::Input;
-use crate::emoji;
 use quicli::prelude::Error;
 use regex;
 

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -1,6 +1,6 @@
 use console::style;
 use dialoguer::Input;
-use emoji;
+use crate::emoji;
 use quicli::prelude::Error;
 use regex;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate remove_dir_all;
 extern crate tempfile;
 extern crate url;
 extern crate walkdir;
+extern crate structopt;
 
 mod cargo;
 mod emoji;
@@ -26,6 +27,7 @@ use console::style;
 use crate::git::GitConfig;
 use crate::projectname::ProjectName;
 use quicli::prelude::*;
+use structopt::StructOpt;
 use std::env;
 use std::path::PathBuf;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,8 @@ mod projectname;
 mod template;
 
 use console::style;
-use git::GitConfig;
-use projectname::ProjectName;
+use crate::git::GitConfig;
+use crate::projectname::ProjectName;
 use quicli::prelude::*;
 use std::env;
 use std::path::PathBuf;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,10 @@ extern crate liquid;
 extern crate quicli;
 extern crate regex;
 extern crate remove_dir_all;
+extern crate structopt;
 extern crate tempfile;
 extern crate url;
 extern crate walkdir;
-extern crate structopt;
 
 mod cargo;
 mod emoji;
@@ -23,13 +23,13 @@ mod progressbar;
 mod projectname;
 mod template;
 
-use console::style;
 use crate::git::GitConfig;
 use crate::projectname::ProjectName;
+use console::style;
 use quicli::prelude::*;
-use structopt::StructOpt;
 use std::env;
 use std::path::PathBuf;
+use structopt::StructOpt;
 
 /// Generate a new Cargo project from a given template
 ///

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,9 +1,9 @@
-use cargo;
+use crate::cargo;
 use console::style;
-use emoji;
+use crate::emoji;
 use indicatif::ProgressBar;
 use liquid;
-use projectname::ProjectName;
+use crate::projectname::ProjectName;
 use quicli::prelude::*;
 use std::fs;
 use std::path::PathBuf;

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,9 +1,9 @@
 use crate::cargo;
-use console::style;
 use crate::emoji;
+use crate::projectname::ProjectName;
+use console::style;
 use indicatif::ProgressBar;
 use liquid;
-use crate::projectname::ProjectName;
 use quicli::prelude::*;
 use std::fs;
 use std::path::PathBuf;

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -1,6 +1,6 @@
 extern crate predicates;
 
-use helpers::project_builder::dir;
+use crate::helpers::project_builder::dir;
 
 use assert_cmd::prelude::*;
 use predicates::prelude::*;

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -1,4 +1,4 @@
-extern crate predicates;
+use predicates;
 
 use crate::helpers::project_builder::dir;
 

--- a/tests/integration/helpers/project_builder.rs
+++ b/tests/integration/helpers/project_builder.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::str;
 use std::sync::atomic::*;
 
-use helpers::project::Project;
+use crate::helpers::project::Project;
 use remove_dir_all::remove_dir_all;
 
 static CNT: AtomicUsize = ATOMIC_USIZE_INIT;

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -1,7 +1,7 @@
-extern crate assert_cmd;
-extern crate predicates;
-extern crate remove_dir_all;
-extern crate tempfile;
+
+
+
+
 
 mod helpers;
 

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -1,8 +1,3 @@
-
-
-
-
-
 mod helpers;
 
 // test modules go here


### PR DESCRIPTION
🆕 do no merge 🆕 

fixes #131 

EDIT: working now, 0.4 quicli asks that you include structopt as a dep, doing this made it work.

----

this will still warn on `cargo fix --edition` with multiple instances of this error:

```
warning: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
  --> src/lib.rs:65:17
   |
65 | #[derive(Debug, StructOpt)]
   |                 ^^^^^^^^^
   |
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
```