### PR TITLE
Fix windows release on appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,6 +14,7 @@ test_script:
 
 before_deploy:
   - ps: |
+        cargo build --release
         $NAME = "cargo-generate-${env:APPVEYOR_REPO_TAG_NAME}-x86_64-pc-windows-msvc"
         New-Item -Path $NAME -ItemType directory
         Copy-Item target/release/cargo-generate.exe "${NAME}/"


### PR DESCRIPTION
This should build a release version only when it is building a tag, thus
fixing the problem where it does not back the exe final in the final
.tar.gz file.