### PR TITLE
Add bluepill and cmdr template links to TEMPLATES.md

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -7,6 +7,8 @@
 - [rust-samp-sdk]: Write samp plugins in Rust, [Sreyas-Sreelal]
 - [actix-tera]: Create a basic web application with Actix-web and Tera, [Otomato]
 - [procmacro-quickstart]: Write procedural macros, [eupn]
+- [bluepill]: Create rust projects for the 'blue pill' stm32 microcontroller board [mendelt]
+- [cmdr]: Write interactive commandline applications [mendelt]
 
 [PyO3]: https://github.com/DD5HT/pyo3-template
 [DD5HT]: https://github.com/DD5HT
@@ -22,3 +24,7 @@
 [Otomato]: https://github.com/otomato-gh
 [procmacro-quickstart]: https://github.com/eupn/rust-procmacro-quickstart-template
 [eupn]: https://github.com/eupn
+[bluepill]: https://github.com/mendelt/bluepill-template
+[cmdr]: https://github.com/mendelt/cmdr-template
+[mendelt]: https://github.com/mendelt
+


### PR DESCRIPTION
I wrote two templates, one for quickly getting started creating rust embedded projects for the blue pill board, a very popular inexpensive micro controller board that I'm playing with and the other for setting up projects using my cmdr crate. I thought you might be interested in linking to these templates.

This is my first pull request on github so please let me know if I'm doing something wrong or silly or stupid or if there is any etiquette or naming convention that I should be following.