### PR TITLE
Feature: Add file for configuring include / exclude of files to template

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,8 +187,10 @@ dependencies = [
  "quicli 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1694,6 +1696,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "typenum"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2006,6 +2016,7 @@ dependencies = [
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
+"checksum toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b8c96d7873fa7ef8bdeb3a9cda3ac48389b4154f32b9803b4bc26220b677b039"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-trie 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "71a9c5b1fe77426cf144cc30e49e955270f5086e31a6441dfa8b32efc09b9d77"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "escargot 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "predicates 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -109,6 +109,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "build_const"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,8 +161,8 @@ dependencies = [
  "rustfix 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_ignored 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "shell-escape 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -177,6 +185,7 @@ dependencies = [
  "dialoguer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "globset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ignore 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -187,7 +196,7 @@ dependencies = [
  "quicli 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -340,8 +349,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "curl 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -515,7 +524,7 @@ name = "escargot"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -541,9 +550,9 @@ name = "failure_derive"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -653,13 +662,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "globset"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bstr 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -718,7 +727,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "globset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -846,7 +855,7 @@ dependencies = [
  "liquid-interpreter 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "liquid-value 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -873,9 +882,9 @@ dependencies = [
  "liquid-error 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "liquid-interpreter 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "liquid-value 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-quote 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -903,7 +912,7 @@ dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "liquid-error 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1103,9 +1112,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "pest 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_meta 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1138,14 +1147,14 @@ name = "proc-macro-hack"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.27"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1157,10 +1166,10 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-hack 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-quote-impl 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1169,8 +1178,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-hack 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1191,16 +1200,16 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "quote"
-version = "0.6.12"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1435,8 +1444,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1473,7 +1482,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1483,20 +1492,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.90"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.90"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1504,7 +1513,7 @@ name = "serde_ignored"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1514,7 +1523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1574,18 +1583,18 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syn"
-version = "0.15.30"
+version = "0.15.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1594,9 +1603,9 @@ name = "synstructure"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1692,7 +1701,7 @@ name = "toml"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1700,7 +1709,7 @@ name = "toml"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1845,6 +1854,7 @@ dependencies = [
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
+"checksum bstr 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e0a692f1c740e7e821ca71a22cf99b9b2322dfa94d10f71443befb1797b3946a"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum cargo 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7fb33d5595dd6719062a5f128d13361d5e72727b11131ee7d1aedd75635772ce"
@@ -1899,7 +1909,7 @@ dependencies = [
 "checksum git2 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "591f8be1674b421644b6c030969520bc3fa12114d2eb467471982ed3e9584e71"
 "checksum git2-curl 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0173e317f8ba21f3fff0f71549fead5e42e67961dbd402bf69f42775f3cc78b4"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4743617a7464bbda3c8aec8558ff2f9429047e025771037df561d383337ff865"
+"checksum globset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "925aa2cac82d8834e2b2a4415b6f6879757fb5c0928fc445ae76461a12eed8f2"
 "checksum globwalk 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce5d04da8cf35b507b2cbec92bbf2d5085292d07cd87637994fd437fe1617bbb"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
@@ -1954,12 +1964,12 @@ dependencies = [
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum predicates 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f3dc50ff273939a7688f8bccd748add1a0822dd6a9aa132b52600c7c45cc6409"
 "checksum proc-macro-hack 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0c1dd4172a1e1f96f709341418f49b11ea6c2d95d53dca08c0f74cbd332d9cf3"
-"checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
+"checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-quote 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fa612543f23fda013e1e6ce30b5285a9d313c6e582e57b4ceca74eb5b85685b5"
 "checksum proc-quote-impl 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f785f0f8cd00b7945efc3f3bdf8205eb06af5aacec598d83e67f41dc8d101fda"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quicli 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9e8539e98d5a5e3cb0398aedac3e9642ead7d3047a459893526710cb5ad86f6c"
-"checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
+"checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
@@ -1992,8 +2002,8 @@ dependencies = [
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)" = "aa5f7c20820475babd2c077c3ab5f8c77a31c15e16ea38687b4c02d3e48680f4"
-"checksum serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)" = "58fc82bec244f168b23d1963b45c8bf5726e9a15a9d146a067f9081aeed2de79"
+"checksum serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5626ac617da2f2d9c48af5515a21d5a480dbd151e01bb1c355e26a3e68113"
+"checksum serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)" = "01e69e1b8a631f245467ee275b8c757b818653c6d704cdbcaeb56b56767b529c"
 "checksum serde_ignored 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "190e9765dcedb56be63b6e0993a006c7e3b071a016a304736e4a315dc01fb142"
 "checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
 "checksum sha-1 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51b9d1f3b5de8a167ab06834a7c883bd197f2191e1dda1a22d9ccfeedbf9aded"
@@ -2004,7 +2014,7 @@ dependencies = [
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3d0760c312538987d363c36c42339b55f5ee176ea8808bbe4543d484a291c8d1"
 "checksum structopt-derive 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "528aeb7351d042e6ffbc2a6fb76a86f9b622fdf7c25932798e7a82cb03bc94c6"
-"checksum syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)" = "66c8865bf5a7cbb662d8b011950060b3c8743dca141b054bf7195b20d314d8e2"
+"checksum syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)" = "eadc09306ca51a40555dd6fc2b415538e9e18bc9f870e47b1a524a79fe2dcf5e"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tar 0.4.22 (registry+https://github.com/rust-lang/crates.io-index)" = "c2167ff53da2a661702b3299f71a91b61b1dffef36b4b2884b1f9c67254c0133"
 "checksum tempfile 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11ce2fe9db64b842314052e2421ac61a73ce41b898dc8e3750398b219c5fc1e0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "escargot 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "predicates 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -109,14 +109,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "build_const"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,8 +153,8 @@ dependencies = [
  "rustfix 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_ignored 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "shell-escape 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -185,7 +177,6 @@ dependencies = [
  "dialoguer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "globset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ignore 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -196,10 +187,8 @@ dependencies = [
  "quicli 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -349,8 +338,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "curl 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -524,7 +513,7 @@ name = "escargot"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -550,9 +539,9 @@ name = "failure_derive"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -662,13 +651,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "globset"
-version = "0.4.4"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "bstr 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -727,7 +716,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "globset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -855,7 +844,7 @@ dependencies = [
  "liquid-interpreter 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "liquid-value 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -882,9 +871,9 @@ dependencies = [
  "liquid-error 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "liquid-interpreter 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "liquid-value 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-quote 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -912,7 +901,7 @@ dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "liquid-error 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1112,9 +1101,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "pest 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_meta 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1147,14 +1136,14 @@ name = "proc-macro-hack"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1166,10 +1155,10 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-hack 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-quote-impl 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1178,8 +1167,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-hack 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1200,16 +1189,16 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "quote"
-version = "0.6.13"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1444,8 +1433,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1482,7 +1471,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1492,20 +1481,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.98"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.98"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1513,7 +1502,7 @@ name = "serde_ignored"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1523,7 +1512,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1583,18 +1572,18 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syn"
-version = "0.15.42"
+version = "0.15.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1603,9 +1592,9 @@ name = "synstructure"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1701,15 +1690,7 @@ name = "toml"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1854,7 +1835,6 @@ dependencies = [
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
-"checksum bstr 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e0a692f1c740e7e821ca71a22cf99b9b2322dfa94d10f71443befb1797b3946a"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum cargo 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7fb33d5595dd6719062a5f128d13361d5e72727b11131ee7d1aedd75635772ce"
@@ -1909,7 +1889,7 @@ dependencies = [
 "checksum git2 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "591f8be1674b421644b6c030969520bc3fa12114d2eb467471982ed3e9584e71"
 "checksum git2-curl 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0173e317f8ba21f3fff0f71549fead5e42e67961dbd402bf69f42775f3cc78b4"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum globset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "925aa2cac82d8834e2b2a4415b6f6879757fb5c0928fc445ae76461a12eed8f2"
+"checksum globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4743617a7464bbda3c8aec8558ff2f9429047e025771037df561d383337ff865"
 "checksum globwalk 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce5d04da8cf35b507b2cbec92bbf2d5085292d07cd87637994fd437fe1617bbb"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
@@ -1964,12 +1944,12 @@ dependencies = [
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum predicates 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f3dc50ff273939a7688f8bccd748add1a0822dd6a9aa132b52600c7c45cc6409"
 "checksum proc-macro-hack 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0c1dd4172a1e1f96f709341418f49b11ea6c2d95d53dca08c0f74cbd332d9cf3"
-"checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+"checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
 "checksum proc-quote 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fa612543f23fda013e1e6ce30b5285a9d313c6e582e57b4ceca74eb5b85685b5"
 "checksum proc-quote-impl 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f785f0f8cd00b7945efc3f3bdf8205eb06af5aacec598d83e67f41dc8d101fda"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quicli 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9e8539e98d5a5e3cb0398aedac3e9642ead7d3047a459893526710cb5ad86f6c"
-"checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+"checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
 "checksum rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
@@ -2002,8 +1982,8 @@ dependencies = [
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5626ac617da2f2d9c48af5515a21d5a480dbd151e01bb1c355e26a3e68113"
-"checksum serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)" = "01e69e1b8a631f245467ee275b8c757b818653c6d704cdbcaeb56b56767b529c"
+"checksum serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)" = "aa5f7c20820475babd2c077c3ab5f8c77a31c15e16ea38687b4c02d3e48680f4"
+"checksum serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)" = "58fc82bec244f168b23d1963b45c8bf5726e9a15a9d146a067f9081aeed2de79"
 "checksum serde_ignored 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "190e9765dcedb56be63b6e0993a006c7e3b071a016a304736e4a315dc01fb142"
 "checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
 "checksum sha-1 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51b9d1f3b5de8a167ab06834a7c883bd197f2191e1dda1a22d9ccfeedbf9aded"
@@ -2014,7 +1994,7 @@ dependencies = [
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3d0760c312538987d363c36c42339b55f5ee176ea8808bbe4543d484a291c8d1"
 "checksum structopt-derive 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "528aeb7351d042e6ffbc2a6fb76a86f9b622fdf7c25932798e7a82cb03bc94c6"
-"checksum syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)" = "eadc09306ca51a40555dd6fc2b415538e9e18bc9f870e47b1a524a79fe2dcf5e"
+"checksum syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)" = "66c8865bf5a7cbb662d8b011950060b3c8743dca141b054bf7195b20d314d8e2"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tar 0.4.22 (registry+https://github.com/rust-lang/crates.io-index)" = "c2167ff53da2a661702b3299f71a91b61b1dffef36b4b2884b1f9c67254c0133"
 "checksum tempfile 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11ce2fe9db64b842314052e2421ac61a73ce41b898dc8e3750398b219c5fc1e0"
@@ -2026,7 +2006,6 @@ dependencies = [
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
-"checksum toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b8c96d7873fa7ef8bdeb3a9cda3ac48389b4154f32b9803b4bc26220b677b039"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-trie 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "71a9c5b1fe77426cf144cc30e49e955270f5086e31a6441dfa8b32efc09b9d77"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ openssl = { version = '0.10.11', optional = true }
 url = "1.7.1"
 structopt = "0.2.15"
 failure = "0.1.5"
+serde = { version = "1.0", features = ["derive"] }
+toml = "0.5.1"
+globset = "0.4.4"
 
 [dev-dependencies]
 predicates = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ structopt = "0.2.15"
 failure = "0.1.5"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5.1"
-globset = "0.4.4"
 
 [dev-dependencies]
 predicates = "0.5.0"

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ If you have a great template that you'd like to feature here, please [file an is
 
 ## Include / Exclude
 
-Templates support a `.gen.toml`, with a "template" section that allows you to configure the files that will be processed by `cargo-generate`.
+Templates support a `cargo-generate.toml`, with a "template" section that allows you to configure the files that will be processed by `cargo-generate`.
 The behavior mirrors Cargo's Include / Exclude functionality, which is [documented here](https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields-optional)
 
 ```toml

--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ If you have a great template that you'd like to feature here, please [file an is
 
 [file an issue or a PR]: https://github.com/ashleygwilliams/cargo-generate/issues
 
+## Include / Exclude
+
+Templates support a `.gen.toml`, with a "template" section that allows you to configure the files that will be processed by `cargo-generate`.
+The behavior mirrors Cargo's Include / Exclude functionality, which is [documented here](https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields-optional)
+
+```toml
+[template]
+include = ["Cargo.toml"]
+# include and exclude are exclusive, if both appear we will use include
+exclude = ["*.c"]
+```
+
 ## License
 
 Licensed under either of

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ supported placeholders are:
 [Liquid Documentation on `date`]: https://shopify.github.io/liquid/filters/date/
 
 You can use those placeholders in the file names of the generated project.  
-For example, for a project named `awesome`, the filename `{{project_name}}.rs` will be transformed to `awesome.rs` during generation.
+For example, for a project named `awesome`, the filename `{{project_name}}.rs` will be transformed to `awesome.rs` during generation. All filenames will be processed for template tags regardless of include / exclude settings.
 
 You can also add a `.genignore` file to your template. The files listed in the `.genignore` file
 will be removed from the local machine when `cargo-generate` is run on the end user's machine.
@@ -78,7 +78,7 @@ If you have a great template that you'd like to feature here, please [file an is
 ## Include / Exclude
 
 Templates support a `cargo-generate.toml`, with a "template" section that allows you to configure the files that will be processed by `cargo-generate`.
-The behavior mirrors Cargo's Include / Exclude functionality, which is [documented here](https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields-optional)
+The behavior mirrors Cargo's Include / Exclude functionality, which is [documented here](https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields-optional). If you are using placeholders in a file name, and also wish to use placeholders in the contents of that file, you should setup your globs to match on the pre-rename filename.
 
 ```toml
 [template]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,188 @@
+use failure::{bail, Fail};
+use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+use globset::GlobSet;
+use toml;
+
+#[derive(Deserialize, Debug, PartialEq)]
+pub struct Config {
+    pub template: Template,
+}
+
+struct Template {
+    pub name: Option<String>,
+    pub repository: Option<String>,
+    pub placeholders: Option<String>,
+    pub parse_matcher: Option<GlobSet>,
+}
+
+#[serde(try_from="TemplateRaw")]
+impl TryFrom<TemplateRaw> for Template {
+    fn from(raw_template_config: TemplateRaw) -> Result<Self, failure::Error> {
+        match raw_template_config {
+            TemplateRaw {
+                include: Some(_),
+                exclude: None,
+                ..
+            } => {
+
+
+            },
+            TemplateRaw {
+                include: None,
+                exclude: Some(_),
+                ..
+            } => {
+
+
+            },
+            TemplateRaw {
+                include: Some(_),
+                exclude: Some(_),
+                ..
+            } => {
+                let err = TemplateConfigError::XorFieldError {
+                    field_a: "include".into(),
+                    field_b: "exclude".into(),
+                };
+
+                Err(err.into())
+            },
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, PartialEq)]
+struct TemplateRaw {
+    pub name: Option<String>,
+    #[serde(rename = "repo")]
+    pub repository: Option<String>,
+    pub placeholders: Option<Vec<String>>,
+    pub include: Option<Vec<String>>,
+    pub exclude: Option<Vec<String>>,
+}
+
+#[derive(Debug, Fail)]
+enum TemplateConfigError {
+    #[fail(
+        display = "config fields {} and {} are mutually exclusive",
+        field_a, field_b
+    )]
+    XorFieldError { field_a: String, field_b: String },
+}
+
+impl Config {
+    pub fn new(path: &Path) -> Result<Self, failure::Error> {
+        let mut file = File::open(path)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+
+        let config: Config = toml::from_str(&contents)?;
+
+        println!("{:#?}", config);
+
+
+        Ok(config)
+    }
+}
+
+impl Template {
+    use globset::Glob;
+
+    pub fn should_parse(&self, path: Path) -> Result<bool, failure::Error> {
+        match self {
+            Template {
+                include: Some(includes),
+                exclude: None,
+                ..
+            } => check_against_whitelist(path, includes),
+            Template {
+                exclude: Some(excludes),
+                include: None,
+                ..
+            } => check_against_blacklist(path, excludes),
+            _ => unreachable!("Precondition violated: include and exclude are mutually exclusive")
+        }
+    }
+
+    fn check_against_whitelist(path: Path, includes: Vec<String>) -> Result<bool, failure::Error> {
+        let mut builder = GlobSetMatcher
+        includes.iter().map(Glob)
+    }
+
+    fn check_against_whitelist(path: Path, includes: Vec<String>) -> Result<bool, failure::Error> {
+
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_deserializes_config() {
+        let test_dir = tempdir().unwrap();
+        let config_path = test_dir.path().join(".gen.toml");
+        let mut file = File::create(&config_path).unwrap();
+
+        file.write_all(
+            r#"
+            [template]
+            name = "cargo-template-foo"
+            repo = "https://github.com/rust-lang-nursery/cargo-template-foo"
+            ignore = ["**/*.ignore"]
+            placeholders = ["authors", "project-name"]
+            include = ["Cargo.toml"]
+        "#
+            .as_bytes(),
+        ).unwrap();
+
+        let config = Config::new(&config_path).unwrap();
+
+        assert_eq!(config.template, Template {
+            name: Some("cargo-template-foo".into()),
+            repository: Some("https://github.com/rust-lang-nursery/cargo-template-foo".into()),
+            ignore: Some(vec!["**/*.ignore".into()]),
+            placeholders: Some(vec!["authors".into(), "project-name".into()]),
+            include: Some(vec!["Cargo.toml".into()]),
+            exclude: None
+        })
+    }
+
+    #[test]
+    fn errors_on_include_and_exclude() {
+        let test_dir = tempdir().unwrap();
+        let config_path = test_dir.path().join(".gen.toml");
+        let mut file = File::create(&config_path).unwrap();
+
+        file.write_all(
+            r#"
+            [template]
+            name = "cargo-template-foo"
+            repo = "https://github.com/rust-lang-nursery/cargo-template-foo"
+            placeholders = ["authors, project-name"]
+            ignore = ["**/*.ignore"]
+            include = ["fileb.toml"]
+            exclude = ["filea.toml"]
+        "#
+            .as_bytes(),
+        ).unwrap();
+
+        let err = Config::new(&config_path)
+            .unwrap_err();
+        let err: &TemplateConfigError = err
+            .downcast_ref()
+            .unwrap();
+    
+        match err {
+            TemplateConfigError::XorFieldError {
+                ..
+            } => (),
+            _ => panic!("incorrect error returned")
+        };
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,13 +55,11 @@ mod tests {
         )
         .unwrap();
 
-        let config = Config::new(&config_path).unwrap();
+        let config = Config::new(&config_path).unwrap().unwrap();
 
         assert_eq!(
-            config.template,
-            TemplateConfig {
-                include: Some(vec!["Cargo.toml".into()]),
-            }
+            config.template.include,
+            Some(vec!["Cargo.toml".into()])
         )
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,29 +1,22 @@
-use failure::{bail, Fail, format_err};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::fs::File;
-use std::io::Read;
 use std::path::Path;
-use std::convert::TryFrom;
-use globset::{GlobSet, GlobSetBuilder, Glob};
+use std::io::Read;
 use toml;
 
 #[derive(Deserialize, Debug)]
 pub struct Config {
-    pub template: Template,
+    pub template: TemplateConfig,
 }
 
 #[derive(Deserialize, Debug)]
-struct Template {
-    pub name: Option<String>,
-    #[serde(rename = "repo")]
-    pub repository: Option<String>,
-    pub placeholders: Option<Vec<String>>,
+pub struct TemplateConfig {
     pub include: Option<Vec<String>>,
     pub exclude: Option<Vec<String>>,
 }
 
 impl Config {
-    pub fn new(path: &Path) -> Result<Self, failure::Error> {
+    pub fn new<P: AsRef<Path>>(path: P) -> Result<Self, failure::Error> {
         let mut file = File::open(path)?;
         let mut contents = String::new();
         file.read_to_string(&mut contents)?;
@@ -49,10 +42,6 @@ mod tests {
         file.write_all(
             r#"
             [template]
-            name = "cargo-template-foo"
-            repo = "https://github.com/rust-lang-nursery/cargo-template-foo"
-            ignore = ["**/*.ignore"]
-            placeholders = ["authors", "project-name"]
             include = ["Cargo.toml"]
         "#
             .as_bytes(),
@@ -60,13 +49,8 @@ mod tests {
 
         let config = Config::new(&config_path).unwrap();
 
-        assert_eq!(config.template, Template {
-            name: Some("cargo-template-foo".into()),
-            repository: Some("https://github.com/rust-lang-nursery/cargo-template-foo".into()),
-            ignore: Some(vec!["**/*.ignore".into()]),
-            placeholders: Some(vec!["authors".into(), "project-name".into()]),
+        assert_eq!(config.template, TemplateConfig {
             include: Some(vec!["Cargo.toml".into()]),
-            exclude: None
         })
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,14 +16,21 @@ pub struct TemplateConfig {
 }
 
 impl Config {
-    pub fn new<P: AsRef<Path>>(path: P) -> Result<Self, failure::Error> {
-        let mut file = File::open(path)?;
-        let mut contents = String::new();
-        file.read_to_string(&mut contents)?;
+    pub fn new<P: AsRef<Path>>(path: P) -> Result<Option<Self>, failure::Error> {
+        match File::open(path) {
+            Ok(mut file) => {
+                let mut contents = String::new();
+                file.read_to_string(&mut contents)?;
 
-        let config: Config = toml::from_str(&contents)?;
+                let config: Config = toml::from_str(&contents)?;
 
-        Ok(config)
+                Ok(Some(config))
+            }
+
+            Err(e) => {
+                Ok(None)
+            }
+        }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,9 +57,6 @@ mod tests {
 
         let config = Config::new(&config_path).unwrap().unwrap();
 
-        assert_eq!(
-            config.template.include,
-            Some(vec!["Cargo.toml".into()])
-        )
+        assert_eq!(config.template.include, Some(vec!["Cargo.toml".into()]))
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,109 +13,13 @@ pub struct Config {
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(try_from = "TemplateRaw")]
-pub struct Template {
-    pub name: Option<String>,
-    pub repository: Option<String>,
-    pub placeholders: Option<Vec<String>>,
-    pub parse_matcher: Option<GlobSet>,
-}
-
-impl TryFrom<TemplateRaw> for Template {
-    type Error = failure::Error;
-    fn try_from(raw_template_config: TemplateRaw) -> Result<Self, Self::Error> {
-        match raw_template_config {
-            TemplateRaw {
-                include: Some(_),
-                exclude: Some(_),
-                ..
-            } => {
-                let err = TemplateConfigError::XorFieldError {
-                    field_a: "include".into(),
-                    field_b: "exclude".into(),
-                };
-
-                Err(err.into())
-            },
-            TemplateRaw {
-                include: Some(whitelist_globs),
-                exclude: None,
-                name, repository, placeholders,
-            } => {
-                let globs: Result<Vec<Glob>, globset::Error> = whitelist_globs.into_iter()
-                    .map(|globstr| Glob::new(&globstr))
-                    .collect();
-
-                globs.and_then(|globs| {
-                    let mut builder = GlobSetBuilder::new();
-
-                    for glob in globs {
-                        builder.add(glob);
-                    }
-
-                    Ok(builder.build())
-                }).and_then(|globset| {
-                    Ok(Template {
-                        name, repository, placeholders,
-                        parse_matcher: Some(globset?)
-                    })
-                }).map_err(|globsetErr| format_err!("globs borked"))
-            },
-            TemplateRaw {
-                include: None,
-                exclude: Some(blacklist_globs),
-                name, repository, placeholders,
-            } => {
-                let globs: Result<Vec<Glob>, globset::Error> = blacklist_globs.into_iter()
-                    .map(|globstr| Glob::new(&globstr))
-                    .collect();
-
-                globs.and_then(|globs| {
-                    let mut builder = GlobSetBuilder::new();
-
-                    for glob in globs {
-                        builder.add(glob);
-                    }
-
-                    Ok(builder.build())
-                }).and_then(|globset| {
-                    Ok(Template {
-                        name, repository, placeholders,
-                        parse_matcher: Some(globset?)
-                    })
-                }).map_err(|globsetErr| format_err!("globs borked"))
-            },
-            TemplateRaw {
-                include: None,
-                exclude: None,
-                name, repository, placeholders,
-            } => {
-                Ok(Template {
-                    name, repository, placeholders,
-                    parse_matcher: None
-                })
-            },
-        }
-    }
-}
-
-#[derive(Deserialize, Debug)]
-struct TemplateRaw {
+struct Template {
     pub name: Option<String>,
     #[serde(rename = "repo")]
     pub repository: Option<String>,
     pub placeholders: Option<Vec<String>>,
     pub include: Option<Vec<String>>,
     pub exclude: Option<Vec<String>>,
-}
-
-#[derive(Debug, Fail)]
-enum TemplateConfigError {
-    #[fail(
-        display = "config fields {} and {} are mutually exclusive",
-        field_a, field_b
-    )]
-    XorFieldError { field_a: String, field_b: String },
 }
 
 impl Config {
@@ -125,9 +29,6 @@ impl Config {
         file.read_to_string(&mut contents)?;
 
         let config: Config = toml::from_str(&contents)?;
-
-        println!("{:#?}", config);
-
 
         Ok(config)
     }
@@ -167,38 +68,5 @@ mod tests {
             include: Some(vec!["Cargo.toml".into()]),
             exclude: None
         })
-    }
-
-    #[test]
-    fn errors_on_include_and_exclude() {
-        let test_dir = tempdir().unwrap();
-        let config_path = test_dir.path().join(".gen.toml");
-        let mut file = File::create(&config_path).unwrap();
-
-        file.write_all(
-            r#"
-            [template]
-            name = "cargo-template-foo"
-            repo = "https://github.com/rust-lang-nursery/cargo-template-foo"
-            placeholders = ["authors, project-name"]
-            ignore = ["**/*.ignore"]
-            include = ["fileb.toml"]
-            exclude = ["filea.toml"]
-        "#
-            .as_bytes(),
-        ).unwrap();
-
-        let err = Config::new(&config_path)
-            .unwrap_err();
-        let err: &TemplateConfigError = err
-            .downcast_ref()
-            .unwrap();
-    
-        match err {
-            TemplateConfigError::XorFieldError {
-                ..
-            } => (),
-            _ => panic!("incorrect error returned")
-        };
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,8 @@ use std::io::ErrorKind;
 use std::path::Path;
 use toml;
 
+pub const CONFIG_FILE_NAME: &str = "cargo-generate.toml";
+
 #[derive(Deserialize, Debug)]
 pub struct Config {
     pub template: TemplateConfig,
@@ -41,7 +43,7 @@ mod tests {
     #[test]
     fn test_deserializes_config() {
         let test_dir = tempdir().unwrap();
-        let config_path = test_dir.path().join(".gen.toml");
+        let config_path = test_dir.path().join(CONFIG_FILE_NAME);
         let mut file = File::create(&config_path).unwrap();
 
         file.write_all(

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
-use std::fs::File;
-use std::io::{ErrorKind, Read};
+use std::fs;
+use std::io::ErrorKind;
 use std::path::Path;
 use toml;
 
@@ -17,11 +17,8 @@ pub struct TemplateConfig {
 
 impl Config {
     pub fn new<P: AsRef<Path>>(path: P) -> Result<Option<Self>, failure::Error> {
-        match File::open(path) {
-            Ok(mut file) => {
-                let mut contents = String::new();
-                file.read_to_string(&mut contents)?;
-
+        match fs::read_to_string(path) {
+            Ok(contents) => {
                 let config: Config = toml::from_str(&contents)?;
 
                 Ok(Some(config))
@@ -37,6 +34,7 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs::File;
     use std::io::Write;
     use tempfile::tempdir;
 

--- a/src/ignoreme.rs
+++ b/src/ignoreme.rs
@@ -5,6 +5,9 @@ use std::ffi::OsStr;
 use std::fs::remove_file;
 use std::path::{Path, PathBuf};
 
+use crate::config::CONFIG_FILE_NAME;
+pub const IGNORE_FILE_NAME: &str = ".genignore";
+
 ///takes the directory path and removes the files/directories specified in the
 /// `.genignore` file
 /// It handles all errors internally
@@ -18,16 +21,14 @@ pub fn remove_uneeded_files(dir: &PathBuf) {
 fn check_if_genignore_exists(location: &PathBuf) -> bool {
     let mut ignore_path = PathBuf::new();
     ignore_path.push(location);
-    ignore_path.push(".genignore");
+    ignore_path.push(IGNORE_FILE_NAME);
     ignore_path.exists()
 }
 
 fn get_ignored(location: &PathBuf) -> Vec<PathBuf> {
-    let ignore_file_name = ".genignore";
-    let config_file_name = ".gen.toml";
     let ignored = WalkBuilder::new(location)
         .standard_filters(false)
-        .add_custom_ignore_filename(OsStr::new(ignore_file_name))
+        .add_custom_ignore_filename(OsStr::new(IGNORE_FILE_NAME))
         .build();
 
     let all = WalkBuilder::new(location).standard_filters(false).build();
@@ -35,8 +36,8 @@ fn get_ignored(location: &PathBuf) -> Vec<PathBuf> {
     let mut all_set = HashSet::new();
     let mut ign_set = HashSet::new();
     let mut output = vec![
-        Path::new(location).join(ignore_file_name),
-        Path::new(location).join(config_file_name),
+        Path::new(location).join(IGNORE_FILE_NAME),
+        Path::new(location).join(CONFIG_FILE_NAME),
     ];
 
     for x in all {

--- a/src/ignoreme.rs
+++ b/src/ignoreme.rs
@@ -19,12 +19,12 @@ fn check_if_genignore_exists(location: &PathBuf) -> bool {
     let mut ignore_path = PathBuf::new();
     ignore_path.push(location);
     ignore_path.push(".genignore");
-    ignore_path.push(".gen.toml");
     ignore_path.exists()
 }
 
 fn get_ignored(location: &PathBuf) -> Vec<PathBuf> {
     let ignore_file_name = ".genignore";
+    let config_file_name = ".gen.toml";
     let ignored = WalkBuilder::new(location)
         .standard_filters(false)
         .add_custom_ignore_filename(OsStr::new(ignore_file_name))
@@ -34,7 +34,7 @@ fn get_ignored(location: &PathBuf) -> Vec<PathBuf> {
 
     let mut all_set = HashSet::new();
     let mut ign_set = HashSet::new();
-    let mut output = vec![Path::new(location).join(ignore_file_name)];
+    let mut output = vec![Path::new(location).join(ignore_file_name), Path::new(location).join(config_file_name)];
 
     for x in all {
         all_set.insert(x.expect("Found invalid path: Aborting").path().to_owned());

--- a/src/ignoreme.rs
+++ b/src/ignoreme.rs
@@ -19,6 +19,7 @@ fn check_if_genignore_exists(location: &PathBuf) -> bool {
     let mut ignore_path = PathBuf::new();
     ignore_path.push(location);
     ignore_path.push(".genignore");
+    ignore_path.push(".gen.toml");
     ignore_path.exists()
 }
 

--- a/src/ignoreme.rs
+++ b/src/ignoreme.rs
@@ -34,7 +34,10 @@ fn get_ignored(location: &PathBuf) -> Vec<PathBuf> {
 
     let mut all_set = HashSet::new();
     let mut ign_set = HashSet::new();
-    let mut output = vec![Path::new(location).join(ignore_file_name), Path::new(location).join(config_file_name)];
+    let mut output = vec![
+        Path::new(location).join(ignore_file_name),
+        Path::new(location).join(config_file_name),
+    ];
 
     for x in all {
         all_set.insert(x.expect("Found invalid path: Aborting").path().to_owned());

--- a/src/ignoreme.rs
+++ b/src/ignoreme.rs
@@ -12,10 +12,8 @@ pub const IGNORE_FILE_NAME: &str = ".genignore";
 /// `.genignore` file
 /// It handles all errors internally
 pub fn remove_uneeded_files(dir: &PathBuf) {
-    if check_if_genignore_exists(dir) {
-        let items = get_ignored(dir);
-        remove_dir_files(items);
-    }
+    let items = get_ignored(dir);
+    remove_dir_files(items);
 }
 
 fn check_if_genignore_exists(location: &PathBuf) -> bool {
@@ -26,12 +24,16 @@ fn check_if_genignore_exists(location: &PathBuf) -> bool {
 }
 
 fn get_ignored(location: &PathBuf) -> Vec<PathBuf> {
-    let ignored = WalkBuilder::new(location)
-        .standard_filters(false)
-        .add_custom_ignore_filename(OsStr::new(IGNORE_FILE_NAME))
-        .build();
-
     let all = WalkBuilder::new(location).standard_filters(false).build();
+    let ignored = if check_if_genignore_exists(location) {
+        WalkBuilder::new(location)
+            .standard_filters(false)
+            .add_custom_ignore_filename(OsStr::new(IGNORE_FILE_NAME))
+            .build()
+    } else {
+        //build another all walker if there is nothing to ignore
+        WalkBuilder::new(location).standard_filters(false).build()
+    };
 
     let mut all_set = HashSet::new();
     let mut ign_set = HashSet::new();

--- a/src/include_exclude.rs
+++ b/src/include_exclude.rs
@@ -1,0 +1,3 @@
+use ignore::gitignore::GitIgnoreBuilder;
+use ignore::Match;
+use std::path::{Path, PathBuf};

--- a/src/include_exclude.rs
+++ b/src/include_exclude.rs
@@ -5,20 +5,20 @@ use std::iter::Iterator;
 use crate::config::TemplateConfig;
 use walkdir::{DirEntry, WalkDir, Result as WDResult};
 
-pub fn create_matcher(template_config: &TemplateConfig, project_dir: &Path) -> Result<impl Iterator<Item = WDResult<DirEntry>>, failure::Error> {
+pub fn create_matcher<'a>(template_config: &'a TemplateConfig, project_dir: &'a Path) -> Result<impl Iterator<Item = WDResult<DirEntry>> + 'a, failure::Error> {
     let mut exclude_builder = GitignoreBuilder::new(project_dir);
-    for rule in template_config.include.unwrap_or_else(Vec::new) {
+    for rule in template_config.include.clone().unwrap_or_else(Vec::new) {
         exclude_builder.add_line(None, &rule)?;
     }
     let exclude_matcher = exclude_builder.build()?;
 
     let mut include_builder = GitignoreBuilder::new(project_dir);
-    for rule in template_config.exclude.unwrap_or_else(Vec::new) {
+    for rule in template_config.exclude.clone().unwrap_or_else(Vec::new) {
         include_builder.add_line(None, &rule)?;
     }
     let include_matcher = include_builder.build()?;
 
-    let should_include = |relative_path: &Path| -> Result<bool, failure::Error> {
+    let should_include = move |relative_path: &Path| -> Result<bool, failure::Error> {
         // "Include" and "exclude" options are mutually exclusive.
         // if no include is made, we will default to ignore_exclude
         // which if there is no options, matches everything
@@ -55,9 +55,29 @@ pub fn create_matcher(template_config: &TemplateConfig, project_dir: &Path) -> R
 
     Ok(WalkDir::new(project_dir)
         .into_iter()
-        .filter_entry(|e| {
+        .filter_entry(move |e| {
             let relative_path = e.path().strip_prefix(project_dir).expect("strip project dir before matching");
             !is_dir(e) && !is_git_metadata(e) && should_include(relative_path).unwrap()
+        }).into_iter())
+}
+
+pub fn create_default_matcher(project_dir: &Path) -> Result<impl Iterator<Item = WDResult<DirEntry>>, failure::Error> {
+    fn is_dir(entry: &DirEntry) -> bool {
+        entry.file_type().is_dir()
+    }
+
+    fn is_git_metadata(entry: &DirEntry) -> bool {
+        entry
+            .path()
+            .to_str()
+            .map(|s| s.contains(".git"))
+            .unwrap_or(false)
+    }
+
+    Ok(WalkDir::new(project_dir)
+        .into_iter()
+        .filter_entry(move |e| {
+            !is_dir(e) && !is_git_metadata(e)
         }).into_iter())
 }
 

--- a/src/include_exclude.rs
+++ b/src/include_exclude.rs
@@ -1,3 +1,63 @@
-use ignore::gitignore::GitIgnoreBuilder;
+use ignore::gitignore::GitignoreBuilder;
 use ignore::Match;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use std::iter::Iterator;
+use crate::config::TemplateConfig;
+use walkdir::{DirEntry, WalkDir, Result as WDResult};
+
+pub fn create_matcher(template_config: &TemplateConfig, project_dir: &Path) -> Result<impl Iterator<Item = WDResult<DirEntry>>, failure::Error> {
+    let mut exclude_builder = GitignoreBuilder::new(project_dir);
+    for rule in template_config.include.unwrap_or_else(Vec::new) {
+        exclude_builder.add_line(None, &rule)?;
+    }
+    let exclude_matcher = exclude_builder.build()?;
+
+    let mut include_builder = GitignoreBuilder::new(project_dir);
+    for rule in template_config.exclude.unwrap_or_else(Vec::new) {
+        include_builder.add_line(None, &rule)?;
+    }
+    let include_matcher = include_builder.build()?;
+
+    let should_include = |relative_path: &Path| -> Result<bool, failure::Error> {
+        // "Include" and "exclude" options are mutually exclusive.
+        // if no include is made, we will default to ignore_exclude
+        // which if there is no options, matches everything
+        if template_config.include.is_none() {
+            match exclude_matcher
+                .matched_path_or_any_parents(relative_path, /* is_dir */ false)
+            {
+                Match::None => Ok(true),
+                Match::Ignore(_) => Ok(false),
+                Match::Whitelist(_) => Ok(true),
+            }
+        } else {
+            match include_matcher
+                .matched_path_or_any_parents(relative_path, /* is_dir */ false)
+            {
+                Match::None => Ok(false),
+                Match::Ignore(_) => Ok(true),
+                Match::Whitelist(_) => Ok(false),
+            }
+        }
+    };
+
+    fn is_dir(entry: &DirEntry) -> bool {
+        entry.file_type().is_dir()
+    }
+
+    fn is_git_metadata(entry: &DirEntry) -> bool {
+        entry
+            .path()
+            .to_str()
+            .map(|s| s.contains(".git"))
+            .unwrap_or(false)
+    }
+
+    Ok(WalkDir::new(project_dir)
+        .into_iter()
+        .filter_entry(|e| {
+            let relative_path = e.path().strip_prefix(project_dir).expect("strip project dir before matching");
+            !is_dir(e) && !is_git_metadata(e) && should_include(relative_path).unwrap()
+        }).into_iter())
+}
+

--- a/src/include_exclude.rs
+++ b/src/include_exclude.rs
@@ -21,7 +21,7 @@ pub fn create_matcher<'a>(
     }
     let exclude_matcher = exclude_builder.build()?;
 
-    let should_include = move |relative_path: &Path| -> Result<bool, failure::Error> {
+    let should_include = move |relative_path: &Path| -> bool {
         // "Include" and "exclude" options are mutually exclusive.
         // if no include is made, we will default to ignore_exclude
         // which if there is no options, matches everything
@@ -29,17 +29,17 @@ pub fn create_matcher<'a>(
             match exclude_matcher
                 .matched_path_or_any_parents(relative_path, /* is_dir */ false)
             {
-                Match::None => Ok(true),
-                Match::Ignore(_) => Ok(false),
-                Match::Whitelist(_) => Ok(true),
+                Match::None => true,
+                Match::Ignore(_) => false,
+                Match::Whitelist(_) => true,
             }
         } else {
             match include_matcher
                 .matched_path_or_any_parents(relative_path, /* is_dir */ false)
             {
-                Match::None => Ok(false),
-                Match::Ignore(_) => Ok(true),
-                Match::Whitelist(_) => Ok(false),
+                Match::None => false,
+                Match::Ignore(_) => true,
+                Match::Whitelist(_) => false,
             }
         }
     };
@@ -62,7 +62,7 @@ pub fn create_matcher<'a>(
                 .path()
                 .strip_prefix(project_dir)
                 .expect("strip project dir before matching");
-            !is_dir(e) && !is_git_metadata(e) && should_include(relative_path).unwrap_or(false)
+            !is_dir(e) && !is_git_metadata(e) && should_include(relative_path)
         } else {
             false
         }

--- a/src/include_exclude.rs
+++ b/src/include_exclude.rs
@@ -1,94 +1,69 @@
 use crate::config::TemplateConfig;
-use ignore::gitignore::GitignoreBuilder;
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use ignore::Match;
-use std::iter::Iterator;
 use std::path::Path;
-use walkdir::{DirEntry, Result as WDResult, WalkDir};
 
-pub fn create_matcher<'a>(
-    template_config: &'a TemplateConfig,
-    project_dir: &'a Path,
-) -> Result<impl Iterator<Item = WDResult<DirEntry>> + 'a, failure::Error> {
-    let mut include_builder = GitignoreBuilder::new(project_dir);
-    for rule in template_config.include.clone().unwrap_or_else(Vec::new) {
-        include_builder.add_line(None, &rule)?;
-    }
-    let include_matcher = include_builder.build()?;
-
-    let mut exclude_builder = GitignoreBuilder::new(project_dir);
-    for rule in template_config.exclude.clone().unwrap_or_else(Vec::new) {
-        exclude_builder.add_line(None, &rule)?;
-    }
-    let exclude_matcher = exclude_builder.build()?;
-
-    let should_include = move |relative_path: &Path| -> bool {
-        // "Include" and "exclude" options are mutually exclusive.
-        // if no include is made, we will default to ignore_exclude
-        // which if there is no options, matches everything
-        if template_config.include.is_none() {
-            match exclude_matcher
-                .matched_path_or_any_parents(relative_path, /* is_dir */ false)
-            {
-                Match::None => true,
-                Match::Ignore(_) => false,
-                Match::Whitelist(_) => true,
-            }
-        } else {
-            match include_matcher
-                .matched_path_or_any_parents(relative_path, /* is_dir */ false)
-            {
-                Match::None => false,
-                Match::Ignore(_) => true,
-                Match::Whitelist(_) => false,
-            }
-        }
-    };
-
-    fn is_dir(entry: &DirEntry) -> bool {
-        entry.file_type().is_dir()
-    }
-
-    fn is_git_metadata(entry: &DirEntry) -> bool {
-        entry
-            .path()
-            .to_str()
-            .map(|s| s.contains(".git"))
-            .unwrap_or(false)
-    }
-
-    Ok(WalkDir::new(project_dir).into_iter().filter(move |e| {
-        if let Ok(e) = e {
-            let relative_path = e
-                .path()
-                .strip_prefix(project_dir)
-                .expect("strip project dir before matching");
-            !is_dir(e) && !is_git_metadata(e) && should_include(relative_path)
-        } else {
-            false
-        }
-    }))
+#[derive(Default)]
+pub struct Matcher {
+    template_config: Option<TemplateConfig>,
+    include_matcher: Option<Gitignore>,
+    exclude_matcher: Option<Gitignore>,
 }
 
-pub fn create_default_matcher(
-    project_dir: &Path,
-) -> Result<impl Iterator<Item = WDResult<DirEntry>>, failure::Error> {
-    fn is_dir(entry: &DirEntry) -> bool {
-        entry.file_type().is_dir()
-    }
-
-    fn is_git_metadata(entry: &DirEntry) -> bool {
-        entry
-            .path()
-            .to_str()
-            .map(|s| s.contains(".git"))
-            .unwrap_or(false)
-    }
-
-    Ok(WalkDir::new(project_dir).into_iter().filter(move |e| {
-        if let Ok(e) = e {
-            !is_dir(e) && !is_git_metadata(e)
-        } else {
-            false
+impl Matcher {
+    pub fn new(
+        template_config: TemplateConfig,
+        project_dir: &Path,
+    ) -> Result<Self, failure::Error> {
+        let mut include_builder = GitignoreBuilder::new(project_dir);
+        for rule in template_config.include.clone().unwrap_or_else(Vec::new) {
+            include_builder.add_line(None, &rule)?;
         }
-    }))
+        let include_matcher = include_builder.build()?;
+
+        let mut exclude_builder = GitignoreBuilder::new(project_dir);
+        for rule in template_config.exclude.clone().unwrap_or_else(Vec::new) {
+            exclude_builder.add_line(None, &rule)?;
+        }
+        let exclude_matcher = exclude_builder.build()?;
+
+        Ok(Matcher {
+            template_config: Some(template_config),
+            include_matcher: Some(include_matcher),
+            exclude_matcher: Some(exclude_matcher),
+        })
+    }
+
+    pub fn should_include(&self, relative_path: &Path) -> bool {
+        match self {
+            Matcher {
+                template_config: Some(template_config),
+                include_matcher: Some(include_matcher),
+                exclude_matcher: Some(exclude_matcher),
+            } => {
+                // "Include" and "exclude" options are mutually exclusive.
+                // if no include is made, we will default to ignore_exclude
+                // which if there is no options, matches everything
+                if template_config.include.is_none() {
+                    match exclude_matcher
+                        .matched_path_or_any_parents(relative_path, /* is_dir */ false)
+                    {
+                        Match::None => true,
+                        Match::Ignore(_) => false,
+                        Match::Whitelist(_) => true,
+                    }
+                } else {
+                    match include_matcher
+                        .matched_path_or_any_parents(relative_path, /* is_dir */ false)
+                    {
+                        Match::None => false,
+                        Match::Ignore(_) => true,
+                        Match::Whitelist(_) => false,
+                    }
+                }
+            }
+            // if no template config, process all files
+            _ => true,
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,16 +3,16 @@ mod config;
 mod emoji;
 mod git;
 mod ignoreme;
+mod include_exclude;
 mod interactive;
 mod progressbar;
 mod projectname;
 mod template;
-mod include_exclude;
 
-use config::Config;
 use crate::git::GitConfig;
 use crate::projectname::ProjectName;
 use cargo;
+use config::Config;
 use console::style;
 use failure;
 use std::env;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod authors;
+mod config;
 mod emoji;
 mod git;
 mod ignoreme;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,9 @@ mod interactive;
 mod progressbar;
 mod projectname;
 mod template;
+mod include_exclude;
 
+use config::Config;
 use crate::git::GitConfig;
 use crate::projectname::ProjectName;
 use cargo;
@@ -137,7 +139,12 @@ fn progress(
     let pbar = progressbar::new();
     pbar.tick();
 
-    template::walk_dir(dir, template, pbar)?;
+    let mut config_path = dir.clone();
+    config_path.push("./gen.toml");
+
+    let template_config = Config::new(config_path)?.template;
+
+    template::walk_dir(dir, template, template_config, pbar)?;
 
     git::init(dir, branch)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ fn progress(
     pbar.tick();
 
     let mut config_path = dir.clone();
-    config_path.push("./gen.toml");
+    config_path.push(".gen.toml");
 
     let template_config = Config::new(config_path)?.map(|c| c.template);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ mod template;
 use crate::git::GitConfig;
 use crate::projectname::ProjectName;
 use cargo;
-use config::Config;
+use config::{Config, CONFIG_FILE_NAME};
 use console::style;
 use failure;
 use std::env;
@@ -140,7 +140,7 @@ fn progress(
     pbar.tick();
 
     let mut config_path = dir.clone();
-    config_path.push(".gen.toml");
+    config_path.push(CONFIG_FILE_NAME);
 
     let template_config = Config::new(config_path)?.map(|c| c.template);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ fn progress(
     let mut config_path = dir.clone();
     config_path.push("./gen.toml");
 
-    let template_config = Config::new(config_path)?.template;
+    let template_config = Config::new(config_path)?.map(|c| c.template);
 
     template::walk_dir(dir, template, template_config, pbar)?;
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -120,7 +120,6 @@ pub fn substitute(
 pub fn walk_dir(
     project_dir: &PathBuf,
     template: liquid::value::Object,
-    config: config::Template,
     pbar: ProgressBar,
 ) -> Result<(), failure::Error> {
     fn is_dir(entry: &DirEntry) -> bool {

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,4 +1,5 @@
 use crate::authors;
+use crate::config;
 use crate::emoji;
 use crate::projectname::ProjectName;
 use console::style;
@@ -119,6 +120,7 @@ pub fn substitute(
 pub fn walk_dir(
     project_dir: &PathBuf,
     template: liquid::value::Object,
+    config: config::Template,
     pbar: ProgressBar,
 ) -> Result<(), failure::Error> {
     fn is_dir(entry: &DirEntry) -> bool {

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,7 +1,7 @@
 use crate::authors;
+use crate::config::TemplateConfig;
 use crate::emoji;
 use crate::include_exclude::*;
-use crate::config::TemplateConfig;
 use crate::projectname::ProjectName;
 use console::style;
 use failure;
@@ -126,24 +126,29 @@ pub fn walk_dir(
     let engine = engine();
 
     //returning iterators is hard :/
-    let matcher = match template_config {
+    match template_config {
         Some(template_config) => {
             for entry in create_matcher(&template_config, project_dir)? {
                 process_entry(entry?.path(), &pbar, &engine, &template)?;
             }
-        },
+        }
         None => {
             for entry in create_default_matcher(project_dir)? {
                 process_entry(entry?.path(), &pbar, &engine, &template)?;
             }
-        },
+        }
     };
 
     pbar.finish_and_clear();
     Ok(())
 }
 
-fn process_entry(filename: &Path, pbar: &ProgressBar, engine: &liquid::Parser, template: &liquid::value::Object) -> Result<(), failure::Error> {
+fn process_entry(
+    filename: &Path,
+    pbar: &ProgressBar,
+    engine: &liquid::Parser,
+    template: &liquid::value::Object,
+) -> Result<(), failure::Error> {
     pbar.set_message(&filename.display().to_string());
 
     let new_contents = engine

--- a/src/template.rs
+++ b/src/template.rs
@@ -125,6 +125,7 @@ pub fn walk_dir(
 ) -> Result<(), failure::Error> {
     let engine = engine();
 
+    //returning iterators is hard :/
     let matcher = match template_config {
         Some(template_config) => {
             for entry in create_matcher(&template_config, project_dir)? {

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -528,3 +528,120 @@ fn it_respects_template_branch_name() {
         .success()
         .stdout(predicates::str::contains("On branch gh-pages").from_utf8());
 }
+
+#[test]
+fn it_only_processes_include_files_in_config() {
+    let template = dir("template")
+        .file(
+            "cargo-generate.toml",
+            r#"[template]
+include = ["included"]
+exclude = ["excluded2"]
+"#,
+        )
+        .file("included", "{{project-name}}")
+        .file("excluded1", "{{should-not-process}}")
+        .file("excluded2", "{{should-not-process}}")
+        .init_git()
+        .build();
+
+    let dir = dir("main").build();
+
+    Command::main_binary()
+        .unwrap()
+        .arg("generate")
+        .arg("--git")
+        .arg(template.path())
+        .arg("--name")
+        .arg("foobar-project")
+        .current_dir(&dir.path())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Done!").from_utf8());
+
+    assert!(dir
+        .read("foobar-project/included")
+        .contains("foobar-project"));
+    assert!(dir
+        .read("foobar-project/excluded1")
+        .contains("{{should-not-process}}"));
+    assert!(dir
+        .read("foobar-project/excluded2")
+        .contains("{{should-not-process}}"));
+}
+
+#[test]
+fn it_doesnt_process_excluded_files_in_config() {
+    let template = dir("template")
+        .file(
+            "cargo-generate.toml",
+            r#"[template]
+exclude = ["excluded"]
+"#,
+        )
+        .file("included1", "{{project-name}}")
+        .file("included2", "{{project-name}}")
+        .file("excluded", "{{should-not-process}}")
+        .init_git()
+        .build();
+
+    let dir = dir("main").build();
+
+    Command::main_binary()
+        .unwrap()
+        .arg("generate")
+        .arg("--git")
+        .arg(template.path())
+        .arg("--name")
+        .arg("foobar-project")
+        .current_dir(&dir.path())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Done!").from_utf8());
+
+    assert!(dir
+        .read("foobar-project/excluded")
+        .contains("{{should-not-process}}"));
+    assert!(dir
+        .read("foobar-project/included1")
+        .contains("foobar-project"));
+    assert!(dir
+        .read("foobar-project/included2")
+        .contains("foobar-project"));
+}
+
+#[test]
+fn it_always_removes_config_file() {
+    let template = dir("template")
+        .file(
+            "Cargo.toml",
+            r#"[package]
+name = "{{project-name}}"
+description = "A wonderful project"
+version = "0.1.0"
+"#,
+        )
+        .file(
+            "cargo-generate.toml",
+            r#"[template]
+"#,
+        )
+        .init_git()
+        .build();
+
+    let dir = dir("main").build();
+
+    Command::main_binary()
+        .unwrap()
+        .arg("gen")
+        .arg("--git")
+        .arg(template.path())
+        .arg("-n")
+        .arg("foobar-project")
+        .current_dir(&dir.path())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Done!").from_utf8());
+
+    assert_eq!(dir.exists("foobar-project/cargo-generate.toml"), false);
+}


### PR DESCRIPTION
Adds support for a file which allows for templates to configure which files should be processed, either using a whitelist method (include), or a blacklist method (exclude), with include being preferred over exclude if both are present. This mirrors the behavior used by cargo for the configuration options of the same name in `Cargo.toml`, and uses some of the same code.

closes #144
closes #124
closes #48
closes #43
closes https://github.com/cloudflare/worker-emscripten-template/issues/1