### PR TITLE
Fix: Only try to remove files that exist

### DIFF
--- a/src/ignoreme.rs
+++ b/src/ignoreme.rs
@@ -55,7 +55,7 @@ fn get_ignored(location: &PathBuf) -> Vec<PathBuf> {
 }
 
 fn remove_dir_files(files: Vec<PathBuf>) {
-    for item in files {
+    for item in files.iter().filter(|file| file.exists()) {
         if item.is_dir() {
             remove_dir_all(&item).unwrap();
             println!("Removed: {:?}", &item)


### PR DESCRIPTION
Fixes a bug I introduced in #174, where the deletion part of `ignoreme.rs` would throw a confusing error message because it was trying to delete a file that didn't exist.

Closes #181.