### PR TITLE
Revert "Merge pull request #161 from k0pernicus/feat_template_tag_in_filename"

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,6 @@ supported placeholders are:
 
 [Liquid Documentation on `date`]: https://shopify.github.io/liquid/filters/date/
 
-You can use those placeholders in the file names of the generated project.  
-For example, for a project named `awesome`, the filename `{{project_name}}.rs` will be transformed to `awesome.rs` during generation. All filenames will be processed for template tags regardless of include / exclude settings.
-
 You can also add a `.genignore` file to your template. The files listed in the `.genignore` file
 will be removed from the local machine when `cargo-generate` is run on the end user's machine.
 The `.genignore` file is always ignored, so there is no need to list it in the `.genignore` file.

--- a/src/template.rs
+++ b/src/template.rs
@@ -10,7 +10,7 @@ use indicatif::ProgressBar;
 use liquid;
 use quicli::prelude::*;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use walkdir::{DirEntry, WalkDir};
 
 fn engine() -> liquid::Parser {
@@ -175,19 +175,6 @@ pub fn walk_dir(
                 )
             })?;
         }
-
-        // Check if the filename does not contains any
-        // template
-        let filename_str = filename.to_str().expect("filename as string");
-        let parsed_filename = engine.clone().parse(filename_str)?.render(&template)?;
-        fs::rename(&filename, Path::new(&parsed_filename)).with_context(|_e| {
-            format!(
-                "{} {} '{}'",
-                emoji::ERROR,
-                style("Error renaming").bold().red(),
-                style(parsed_filename).bold()
-            )
-        })?;
     }
 
     pbar.finish_and_clear();

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -138,42 +138,6 @@ extern crate {{crate_name}};
 }
 
 #[test]
-fn it_substitutes_filename() {
-    let template = dir("template")
-        .file(
-            "main.rs",
-            r#"
-extern crate {{crate_name}};
-"#,
-        )
-        .file(
-            "{{project-name}}.rs",
-            r#"
-println!("Welcome in {{project-name}}");
-"#,
-        )
-        .init_git()
-        .build();
-
-    let dir = dir("main").build();
-
-    Command::main_binary()
-        .unwrap()
-        .arg("generate")
-        .arg("--git")
-        .arg(template.path())
-        .arg("--name")
-        .arg("foobar-project")
-        .current_dir(&dir.path())
-        .assert()
-        .success()
-        .stdout(predicates::str::contains("Done!").from_utf8());
-
-    assert_eq!(dir.exists("foobar-project/main.rs"), true);
-    assert_eq!(dir.exists("foobar-project/foobar-project.rs"), true);
-}
-
-#[test]
 fn short_commands_work() {
     let template = dir("template")
         .file(


### PR DESCRIPTION
PR #161 had some integration issues with #174, as well as some footguns.

- what to do about using template tags in filenames along with the include option in `cargo-generate.toml` when you can't specify a filename with curly braces in it ergonomically using glob syntax
- what to do about characters coming out of a template tag and being invalid when part of a filename.

Since #174 is unblocking lots of people and templates, we should revert #161 and go back to the design stage to figure out a more compatible way to allow for template creators to rename their files as part of generation.