### PR TITLE
Add warning if config has include and exclude

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use serde::Deserialize;
 use std::fs;
 use std::io::ErrorKind;
 use std::path::Path;
+use crate::emoji;
 use toml;
 
 pub const CONFIG_FILE_NAME: &str = "cargo-generate.toml";
@@ -22,6 +23,14 @@ impl Config {
         match fs::read_to_string(path) {
             Ok(contents) => {
                 let config: Config = toml::from_str(&contents)?;
+
+                match config.template {
+                    TemplateConfig {
+                        include: Some(_),
+                        exclude: Some(_),
+                    } => println!("{0} Your {1} contains both an include and exclude list. Only the include list will be considered. You should remove the exclude list for clarity. {0}", emoji::WARN, CONFIG_FILE_NAME),
+                    _ => ()
+                }
 
                 Ok(Some(config))
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,13 +136,13 @@ fn progress(
 ) -> Result<(), failure::Error> {
     let template = template::substitute(name, force)?;
 
-    let pbar = progressbar::new();
-    pbar.tick();
-
     let mut config_path = dir.clone();
     config_path.push(CONFIG_FILE_NAME);
 
     let template_config = Config::new(config_path)?.map(|c| c.template);
+
+    let pbar = progressbar::new();
+    pbar.tick();
 
     template::walk_dir(dir, template, template_config, pbar)?;
 


### PR DESCRIPTION
```
🌀  🐑  Generating a new webpack worker project with name 'test504'...
🔧   Creating project called `test504`...
⚠️   Your cargo-generate.toml contains both an include and exclude list. Only the include list will be considered. You should remove the exclude list for clarity. ⚠️
Removed: "/Users/malonso/cf-repos/scratch/test504/.genignore"
Removed: "/Users/malonso/cf-repos/scratch/test504/cargo-generate.toml"
Removed: "/Users/malonso/cf-repos/scratch/test504/LICENSE_APACHE"
Removed: "/Users/malonso/cf-repos/scratch/test504/LICENSE_MIT"
✨   Done! New project created /Users/malonso/cf-repos/scratch/test504
```

warn emoji renders correctly in terminal