### PR TITLE
Fix unknown filters

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -50,7 +50,7 @@ impl liquid::compiler::Filter for KebabCaseFilter {
 
 #[derive(Clone, liquid_derive::ParseFilter, liquid_derive::FilterReflection)]
 #[filter(
-    name = "kebab_case",
+    name = "pascal_case",
     description = "Change text to PascalCase.",
     parsed(PascalCaseFilter)
 )]
@@ -74,14 +74,14 @@ impl liquid::compiler::Filter for PascalCaseFilter {
 
 #[derive(Clone, liquid_derive::ParseFilter, liquid_derive::FilterReflection)]
 #[filter(
-    name = "kebab_case",
+    name = "snake_case",
     description = "Change text to snake_case.",
     parsed(SnakeCaseFilter)
 )]
 pub struct SnakeCaseFilterParser;
 
 #[derive(Debug, Default, liquid_derive::Display_filter)]
-#[name = "pascal_case"]
+#[name = "snake_case"]
 struct SnakeCaseFilter;
 
 impl liquid::compiler::Filter for SnakeCaseFilter {

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -757,3 +757,40 @@ fn it_doesnt_warn_with_neither_config_nor_ignore() {
         .stdout(predicates::str::contains("neither").count(0).from_utf8())
         .stdout(predicates::str::contains("Done!").from_utf8());
 }
+
+#[test]
+fn it_applies_filters() {
+    let template = dir("template")
+        .file(
+            "filters.txt",
+            r#"kebab-case = {{crate_name | kebab_case}}
+    PascalCase = {{crate_name | pascal_case}}
+    snake_case = {{crate_name | snake_case}}
+    "#,
+        )
+        .init_git()
+        .build();
+    let dir = dir("main").build();
+
+    Command::main_binary()
+        .unwrap()
+        .arg("generate")
+        .arg("--git")
+        .arg(template.path())
+        .arg("--name")
+        .arg("foobar-project")
+        .current_dir(&dir.path())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Done!").from_utf8());
+
+    assert!(dir
+        .read("foobar-project/filters.txt")
+        .contains("kebab-case = foobar-project"));
+    assert!(dir
+        .read("foobar-project/filters.txt")
+        .contains("PascalCase = FoobarProject"));
+    assert!(dir
+        .read("foobar-project/filters.txt")
+        .contains("snake_case = foobar_project"));
+}


### PR DESCRIPTION
Fixes the filter macro names for `pascal_case` and `snake_case`.

Also, I checked the docs and only found info for the date filter. Should we add a note about how to use these other filters in the README?

Closes #180 