### PR TITLE
Make cargo-generate a binary explicitly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,7 @@ tempfile = "3.0.2"
 
 [features]
 vendored-openssl = ['openssl/vendored']
+
+[[bin]]
+path = "src/main.rs"
+name = "cargo-generate"


### PR DESCRIPTION
One of our downstream dependencies broke semver, so currently `cargo install cargo-generate` fails. This PR makes us a binary explicitly, so when uploading to crates.io via cargo the lockfile is included so when a downstream dependency breaks semver, it doesn't break `cargo-generate`