### PR TITLE
Add verbose flag for printing removed files

### DIFF
--- a/src/ignoreme.rs
+++ b/src/ignoreme.rs
@@ -56,16 +56,16 @@ fn get_ignored(location: &PathBuf) -> Vec<PathBuf> {
 
 fn remove_dir_files(files: Vec<PathBuf>, verbose: bool) {
     for item in files.iter().filter(|file| file.exists()) {
-        let removed_message = format!("Removed: {}", &item.display());
+        let ignore_message = format!("Ignoring: {}", &item.display());
         if item.is_dir() {
             remove_dir_all(&item).unwrap();
             if verbose {
-                println!("{}", removed_message);
+                println!("{}", ignore_message);
             }
         } else if item.is_file() {
             remove_file(&item).unwrap();
             if verbose {
-                println!("{}", removed_message);
+                println!("{}", ignore_message);
             }
         } else {
             println!(

--- a/src/ignoreme.rs
+++ b/src/ignoreme.rs
@@ -11,9 +11,9 @@ pub const IGNORE_FILE_NAME: &str = ".genignore";
 ///takes the directory path and removes the files/directories specified in the
 /// `.genignore` file
 /// It handles all errors internally
-pub fn remove_uneeded_files(dir: &PathBuf) {
+pub fn remove_unneeded_files(dir: &PathBuf, verbose: bool) {
     let items = get_ignored(dir);
-    remove_dir_files(items);
+    remove_dir_files(items, verbose);
 }
 
 fn check_if_genignore_exists(location: &PathBuf) -> bool {
@@ -54,14 +54,19 @@ fn get_ignored(location: &PathBuf) -> Vec<PathBuf> {
     output
 }
 
-fn remove_dir_files(files: Vec<PathBuf>) {
+fn remove_dir_files(files: Vec<PathBuf>, verbose: bool) {
     for item in files.iter().filter(|file| file.exists()) {
+        let removed_message = format!("Removed: {}", &item.display());
         if item.is_dir() {
             remove_dir_all(&item).unwrap();
-            println!("Removed: {}", &item.display())
+            if verbose {
+                println!("{}", removed_message);
+            }
         } else if item.is_file() {
             remove_file(&item).unwrap();
-            println!("Removed: {}", &item.display())
+            if verbose {
+                println!("{}", removed_message);
+            }
         } else {
             println!(
                 "The given paths are neither files nor directories! {}",

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -247,6 +247,43 @@ version = "0.1.0"
 }
 
 #[test]
+fn it_prints_ignored_files_with_verbose() {
+    let template = dir("template")
+        .file(
+            "Cargo.toml",
+            r#"[package]
+name = "{{project-name}}"
+description = "A wonderful project"
+version = "0.1.0"
+"#,
+        )
+        .file(
+            ".genignore",
+            r#"deleteme.sh
+*.trash
+"#,
+        )
+        .file("deleteme.trash", r#"This is trash"#)
+        .init_git()
+        .build();
+
+    let dir = dir("main").build();
+
+    Command::main_binary()
+        .unwrap()
+        .arg("gen")
+        .arg("--git")
+        .arg(template.path())
+        .arg("-n")
+        .arg("foobar-project")
+        .arg("--verbose")
+        .current_dir(&dir.path())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("deleteme.trash").from_utf8());
+}
+
+#[test]
 fn it_always_removes_genignore_file() {
     let template = dir("template")
         .file(


### PR DESCRIPTION
This PR reduces the output for generate commands that ignore a lot of files. The old printout can be accessed with the `--verbose` flag.

My thinking behind this is that when people are running `cargo generate` on a given project, they probably don't care too much what the template is configured to ignore, but the output can definitely be helpful for the template maintainers.

**Before:**

```console
$ cargo generate --name my-site --git https://github.com/cloudflare/worker-sites-template
🔧   Creating project called `my-site`...
Removed: "/Users/averyharnish/Documents/work/_tmp/my-site/.genignore"
Removed: "/Users/averyharnish/Documents/work/_tmp/my-site/cargo-generate.toml"
Removed: "/Users/averyharnish/Documents/work/_tmp/my-site/LICENSE_APACHE"
Removed: "/Users/averyharnish/Documents/work/_tmp/my-site/LICENSE_MIT"
✨   Done! New project created /Users/averyharnish/Documents/work/_tmp/my-site
```

**After:**

```console
$ cargo generate --name my-site --git https://github.com/cloudflare/worker-sites-template
🔧   Creating project called `my-site`...
✨   Done! New project created /Users/averyharnish/Documents/work/_tmp/my-site
```

```console
$ cargo generate --name my-site --git https://github.com/cloudflare/worker-sites-template --verbose
🔧   Creating project called `my-site`...
Removed: "/Users/averyharnish/Documents/work/_tmp/my-site/.genignore"
Removed: "/Users/averyharnish/Documents/work/_tmp/my-site/cargo-generate.toml"
Removed: "/Users/averyharnish/Documents/work/_tmp/my-site/LICENSE_APACHE"
Removed: "/Users/averyharnish/Documents/work/_tmp/my-site/LICENSE_MIT"
✨   Done! New project created /Users/averyharnish/Documents/work/_tmp/my-site
```