### PR TITLE
allows repo name for --git [URL] instead of the entire url

### DIFF
--- a/tests/integration/helpers/project_builder.rs
+++ b/tests/integration/helpers/project_builder.rs
@@ -38,7 +38,7 @@ fn root(name: &str) -> PathBuf {
     me.pop(); // chop off `debug` / `release`
     me.push("generated-tests");
     me.push(&format!("test-{}-{}", idx, name));
-    return me;
+    me
 }
 
 impl ProjectBuilder {


### PR DESCRIPTION
This allows users to instead of using the entire url to only type the name of the repo/project. I realize this is only partially useful as most people will simply paste the url from the TEMPLATES.md file. That being said if this seems useful cool, otherwise I understand completely.