### PR TITLE
ignore files in .genignore before walking/substitution

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,11 +147,11 @@ fn progress(
     let pbar = progressbar::new();
     pbar.tick();
 
+    ignoreme::remove_unneeded_files(dir, verbose);
+
     template::walk_dir(dir, template, template_config, pbar)?;
 
     git::init(dir, branch)?;
-
-    ignoreme::remove_unneeded_files(dir, verbose);
 
     gen_success(dir);
 


### PR DESCRIPTION
### changes
* ignores files listed in .genignore _before_ walking the project template and doing substitution 

### tl;dr
This should fix scenarios where liquid variables are causing errors in files that are ignored. Fixes #236 