### PR TITLE
Add rust-cli-template to TEMPLATES.md

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -17,6 +17,8 @@
 - [QuickStart WebAssembly]: Create a quick Webassembly application with Rust, [Pankaj Chaudhary]
 - [Win32]: Write low-level Win32 applications, [ArmsOfSorrow]
 - [rust-starter]: Bootstrap a Rust CLI application with Clap, [omarabid]
+- [rust-cli-template]: Write a CLI with [color_eyre] and [tracing] already set
+  up, in addition to benchmarking and testing boilerplate [Rebecca Turner]
 
 [PyO3]: https://github.com/DD5HT/pyo3-template
 [DD5HT]: https://github.com/DD5HT
@@ -51,3 +53,7 @@
 [ArmsOfSorrow]: https://github.com/ArmsOfSorrow
 [rust-starter]: https://github.com/omarabid/rust-starter-generate
 [omarabid]: https://github.com/omarabid
+[rust-cli-t emplate]: https://github.com/9999years/rust-cli-template
+[Rebecca Turner]: https://github.com/9999years
+[color_eyre]: https://docs.rs/color_eyre
+[tracing]: https://docs.rs/tracing

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -53,7 +53,7 @@
 [ArmsOfSorrow]: https://github.com/ArmsOfSorrow
 [rust-starter]: https://github.com/omarabid/rust-starter-generate
 [omarabid]: https://github.com/omarabid
-[rust-cli-t emplate]: https://github.com/9999years/rust-cli-template
+[rust-cli-template]: https://github.com/9999years/rust-cli-template
 [Rebecca Turner]: https://github.com/9999years
 [color_eyre]: https://docs.rs/color_eyre
 [tracing]: https://docs.rs/tracing


### PR DESCRIPTION
Add a link to [rust-cli-template] in `TEMPLATES.md`.

From the template's `README.md`, rust-cli-template includes:

- Decently filled out `Cargo.toml`
- Support for benchmarking with [Criterion]
- A bunch of useful default dependencies and dev-dependencies.
    - [pretty_assertions] and [indoc] for tests
    - [color_eyre] with [tracing], [tracing-subscriber], and [tracing-error]
      for error reporting and logging
    - [structopt] for command-line argument parsing (to be replaced with clap3
      whenever that's released)
- A lib target for doc tests and a bin target for the actual tool

[Criterion]: https://github.com/bheisler/criterion.rs
[pretty_assertions]: https://docs.rs/pretty_assertions
[indoc]: https://docs.rs/indoc
[color_eyre]: https://docs.rs/color_eyre
[tracing]: https://docs.rs/tracing
[tracing-subscriber]: https://docs.rs/tracing-subscriber
[tracing-error]: https://docs.rs/tracing-error
[structopt]: https://docs.rs/structopt
[cargo-generate]: https://github.com/ashleygwilliams/cargo-generate


[rust-cli-template]: https://github.com/9999years/rust-cli-template