### PR TITLE
Use default remote branch instead of `master`

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -56,12 +56,14 @@ pub fn remove_history(project_dir: &PathBuf) -> Result<(), failure::Error> {
     Ok(())
 }
 
-pub fn init(project_dir: &PathBuf, branch: &str) -> Result<GitRepository, failure::Error> {
-    Ok(GitRepository::init_opts(
-        project_dir,
-        RepositoryInitOptions::new()
-            .bare(false)
-            .initial_head(branch),
-    )
-    .context("Couldn't init new repository")?)
+pub fn init(
+    project_dir: &PathBuf,
+    branch: Option<String>,
+) -> Result<GitRepository, failure::Error> {
+    let mut opts = RepositoryInitOptions::new();
+    opts.bare(false);
+    if let Some(branch) = branch {
+        opts.initial_head(&branch);
+    }
+    Ok(GitRepository::init_opts(project_dir, &opts).context("Couldn't init new repository")?)
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -16,7 +16,7 @@ pub struct GitConfig {
 }
 
 impl GitConfig {
-    pub fn new(git: String, branch: String) -> Result<Self, failure::Error> {
+    pub fn new(git: String, branch: GitReference) -> Result<Self, failure::Error> {
         let remote = match Url::parse(&git) {
             Ok(u) => u,
             Err(ParseError::RelativeUrlWithoutBase) => {
@@ -34,10 +34,7 @@ impl GitConfig {
             Err(_) => return Err(format_err!("Failed parsing git remote: {}", &git)),
         };
 
-        Ok(GitConfig {
-            remote,
-            branch: GitReference::Branch(branch),
-        })
+        Ok(GitConfig { remote, branch })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,8 +79,11 @@ pub fn generate(args: Args) -> Result<(), failure::Error> {
 fn create_git(args: Args, name: &ProjectName) -> Result<(), failure::Error> {
     let force = args.force;
     let branch_str = args.branch.clone();
-    let branch = GitReference::Branch(args.branch.unwrap_or_else(|| "master".to_string()));
-    let config = GitConfig::new(args.git, branch)?;
+    let branch = args
+        .branch
+        .map(GitReference::Branch)
+        .unwrap_or_else(|| GitReference::Rev("FETCH_HEAD".to_string()));
+    let config = GitConfig::new(args.git.clone(), branch)?;
     let verbose = args.verbose;
     if let Some(dir) = &create_project_dir(&name, force) {
         match git::create(dir, config) {

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -442,7 +442,7 @@ version = "0.1.0"
 
 #[test]
 fn it_allows_a_git_branch_to_be_specified() {
-    // Build and commit on master
+    // Build and commit on branch named 'main'
     let template = dir("template")
         .file(
             "Cargo.toml",
@@ -570,7 +570,7 @@ fn it_respects_template_branch_name() {
     Command::new("git")
         .arg("branch")
         .arg("-m")
-        .arg("master")
+        .arg("main")
         .arg("gh-pages")
         .current_dir(template.path())
         .assert()

--- a/tests/integration/helpers/project_builder.rs
+++ b/tests/integration/helpers/project_builder.rs
@@ -88,16 +88,18 @@ impl ProjectBuilder {
 
             Command::new("git")
                 .arg("init")
+                // Don't fail if `init.defaultBranch` is set to something else like "main"
+                .arg("--initial-branch=main")
                 .current_dir(&self.root)
                 .assert()
                 .success();
 
             if let Some(ref branch) = self.branch {
-                // Create dummy content in master to aid testing
+                // Create dummy content in "main" branch to aid testing
 
                 fs::File::create(self.root.join("dummy.txt"))
                     .expect("Failed to create dummy")
-                    .write_all(b"master dummy")
+                    .write_all(b"main dummy")
                     .expect("Couldn't write out dummy text");
 
                 Command::new("git")
@@ -110,7 +112,7 @@ impl ProjectBuilder {
                 Command::new("git")
                     .arg("commit")
                     .arg("--message")
-                    .arg("initial master commit")
+                    .arg("initial main commit")
                     .current_dir(&self.root)
                     .assert()
                     .success();
@@ -153,7 +155,7 @@ impl ProjectBuilder {
             if self.branch.is_some() {
                 Command::new("git")
                     .arg("checkout")
-                    .arg("master")
+                    .arg("main")
                     .current_dir(&self.root)
                     .assert()
                     .success();


### PR DESCRIPTION
Default to cloning the template repository's default branch, instead of hard-coding a default of `master` if `--branch` isn't given.

This has two benefits:

1. For repositories with a default branch other than `master`, `--branch` is no longer required when using `cargo generate`
2. If the user has `init.defaultBranch` ([new in Git 2.28.0](https://github.blog/2020-07-27-highlights-from-git-2-28/)) set to something other than `master`, the newly-created repository has that branch name.

As an added bonus, ~~when I~~ if a user with `init.defaultBranch` set to something other than `master` runs the integration tests, they don't all fail because the `master` branch can't be found.