### PR TITLE
Handle default branch properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,9 +131,9 @@ checksum = "81a18687293a1546b67c246452202bbbf143d239cb43494cc163da14979082da"
 
 [[package]]
 name = "cargo"
-version = "0.46.1"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd9c4b3682fcfa94d46cca36d93c93d068cd83a025b64d4bbb3fd7389a8b3d8c"
+checksum = "ec81821e28b074a0b8bc330a446256e7ec451a8be7b7bfad3bd47947f54c6b0b"
 dependencies = [
  "anyhow",
  "atty",
@@ -169,7 +169,6 @@ dependencies = [
  "num_cpus",
  "opener",
  "percent-encoding",
- "remove_dir_all",
  "rustc-workspace-hack",
  "rustfix",
  "same-file",
@@ -323,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.7.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -333,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
+checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "crates-io"
@@ -565,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.11"
+version = "0.13.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e094214efbc7fdbbdee952147e493b00e99a4e52817492277e98967ae918165"
+checksum = "ca6f1a0238d7f8f8fd5ee642f4ebac4dbc03e03d1f78fbe7a3ede35dcf7e2224"
 dependencies = [
  "bitflags",
  "libc",
@@ -771,9 +770,9 @@ checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.13+1.0.1"
+version = "0.12.14+1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069eea34f76ec15f2822ccf78fe0cdb8c9016764d0a12865278585a74dbdeae5"
+checksum = "8f25af58e6495f7caf2919d08f212de550cfa3ed2f5e744988938ea292b9f549"
 dependencies = [
  "cc",
  "libc",
@@ -1559,9 +1558,9 @@ checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
 
 [[package]]
 name = "toml"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
+checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cargo = "0.46.1"
+cargo = "0.49.0"
 console = "0.11.3"
 dialoguer = "0.6.2"
 indicatif = "0.15.0"
-git2 = "0.13.8"
+git2 = "0.13.12"
 tempfile = "3.1"
 regex = "1.3"
 heck = "0.3.1"

--- a/src/git.rs
+++ b/src/git.rs
@@ -154,10 +154,7 @@ mod tests {
         assert!(GitConfig::new("aslkdgjlaskjdglskj", None).is_err());
 
         // Local path does exist.
-        let remote = GitConfig::new("src", None)
-            .unwrap()
-            .remote
-            .into_string();
+        let remote = GitConfig::new("src", None).unwrap().remote.into_string();
         assert!(
             remote.ends_with("/src"),
             format!("remote {} ends with /src", &remote)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,14 +86,13 @@ pub fn generate(args: Args) -> Result<()> {
 
 fn create_git(args: Args, name: &ProjectName) -> Result<()> {
     let force = args.force;
-    let branch = args.branch.as_deref().unwrap_or("master");
-    let config = GitConfig::new_abbr(&args.git, branch.to_owned())?;
+    let config = GitConfig::new_abbr(&args.git, args.branch.to_owned())?;
     let verbose = args.verbose;
     if let Some(dir) = &create_project_dir(&name, force) {
         match git::create(dir, config) {
-            Ok(_) => {
+            Ok(branch) => {
                 git::remove_history(dir)?;
-                progress(name, dir, force, branch, verbose)?;
+                progress(name, dir, force, &branch, verbose)?;
             }
             Err(e) => anyhow::bail!(
                 "{} {} {}",


### PR DESCRIPTION
Hi,

Thank you for `cargo-generate` :heart: 

I would like to introduce this change to make `cargo-generate` more friendly with repositories that don't use "master" as the default branch. I think this is particularly relevant now that GitHub also uses "main" instead of "master".

I would have like to fix it on cargo directly but there are some compatibility issues. But I don't think this is an issue for `cargo-generate`. This is why I'm introducing this change here.

I was personally bothered by it because I tried to make a new template but it failed because I was using the "main" branch as default branch.