### PR TITLE
Cargo.toml: remove "readme" field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ authors = [
 ]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/ashleygwilliams/cargo-generate"
-readme = "README.md"
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
It is no more required. See [here](https://doc.rust-lang.org/cargo/reference/manifest.html#the-readme-field)