### PR TITLE
Ignore .cargo-ok files by default.

### DIFF
--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -357,6 +357,39 @@ version = "0.1.0"
 }
 
 #[test]
+fn it_always_removes_cargo_ok_file() {
+    let template = dir("template")
+        .file(
+            "Cargo.toml",
+            r#"[package]
+name = "{{project-name}}"
+description = "A wonderful project"
+version = "0.1.0"
+"#,
+        )
+        .file(".genignore", r#"farts"#)
+        .init_git()
+        .build();
+
+    let dir = dir("main").build();
+
+    binary()
+        .arg("gen")
+        .arg("--git")
+        .arg(template.path())
+        .arg("-n")
+        .arg("foobar-project")
+        .arg("--branch")
+        .arg("main")
+        .current_dir(&dir.path())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Done!").from_utf8());
+
+    assert_eq!(dir.exists("foobar-project/.cargo-ok"), false);
+}
+
+#[test]
 fn it_removes_genignore_files_before_substitution() {
     let template = dir("template")
         .file(


### PR DESCRIPTION
I was going to write a script that wraps `cargo-generate` and then automatically deletes this, but it's pretty easy to just add to the default ignore set.

This file serves no purpose and causes clutter, and many users either fail to notice it or think it should be kept: https://sourcegraph.com/search?q=file:.cargo-ok&patternType=literal

I suspect any case where this file is actually part of the template is either broken or at best fragile (as it's existence can prevent cargo from detecting failure to extract the tarball), depending on cargo's behavior. (That said, if any do exist, it seems very likely they came into existence by something like using `cargo-generate` to generate a template repo).

Fixes #259